### PR TITLE
Cancellation exception is not an error

### DIFF
--- a/server/Helpers/LoggingMiddlewareHelper.cs
+++ b/server/Helpers/LoggingMiddlewareHelper.cs
@@ -12,6 +12,17 @@ public static class LoggingMiddlewareHelper
             {
                 await next();
             }
+            catch (OperationCanceledException ex)
+                when (ctx.Request.Path.StartsWithSegments("/api") && ctx.RequestAborted.IsCancellationRequested)
+            {
+                app.Logger.LogInformation(
+                    ex,
+                    "API request was canceled by the client: {Method} {Path}. ContentLength={ContentLength}.",
+                    ctx.Request.Method,
+                    ctx.Request.Path,
+                    ctx.Request.ContentLength);
+                throw;
+            }
             catch (Exception ex) when (ctx.Request.Path.StartsWithSegments("/api"))
             {
                 app.Logger.LogError(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request logging to treat client cancellations separately from server errors.
  * Canceled API requests now produce an informational log entry instead of an error, while other API failures continue to be logged as errors.
  * Existing warning logs for API responses with error status codes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->