### PR TITLE
Add project identification workflow setup checklist

### DIFF
--- a/client/src/components/FlatFileImportPanel.tsx
+++ b/client/src/components/FlatFileImportPanel.tsx
@@ -10,7 +10,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { useRef, useState } from 'react';
 import { DataTable } from '@/shared/dataTable.tsx';
 
-type ImportDatasetId =
+export type ImportDatasetId =
   | 'active-projects'
   | 'all-projects'
   | 'assistance-listing-numbers';
@@ -125,7 +125,7 @@ interface HistoricalValidationErrorRow {
   sourceHeader: string;
 }
 
-const datasetOptions: ImportDatasetOption[] = [
+export const datasetOptions: ImportDatasetOption[] = [
   { id: 'all-projects', label: 'All Projects' },
   { id: 'active-projects', label: 'Active Projects' },
   {
@@ -326,6 +326,189 @@ export function FlatFileImportPanel() {
           <span>
             Imported {success.rowsImported.toLocaleString()} rows from{' '}
             {success.filename}.
+          </span>
+        </div>
+      )}
+
+      {validation && <ValidationResults validation={validation} />}
+    </div>
+  );
+}
+
+export function FlatFileImportChecklistItem({
+  completed,
+  dataset,
+  latestImport,
+  markDonePending,
+  onMarkDone,
+  ready,
+  stale,
+  staleReason,
+}: {
+  completed: boolean;
+  dataset: ImportDatasetId;
+  latestImport?: RecentImportResponse | null;
+  markDonePending: boolean;
+  onMarkDone: () => void;
+  ready: boolean;
+  stale: boolean;
+  staleReason?: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [selectedImportId, setSelectedImportId] = useState<number | null>(null);
+  const [validation, setValidation] = useState<ImportValidationResponse | null>(
+    null
+  );
+  const [success, setSuccess] = useState<ImportSuccessResponse | null>(null);
+  const importDetailQuery = useQuery({
+    enabled: selectedImportId !== null,
+    queryFn: () => fetchImportDetail(selectedImportId!),
+    queryKey: ['imports', 'detail', selectedImportId],
+  });
+  const label = getDatasetLabel(dataset);
+
+  const clearInputFileSelection = () => {
+    setFile(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const mutation = useMutation({
+    mutationFn: uploadImport,
+    onError: (error, variables) => {
+      setSuccess(null);
+      if (error instanceof HttpError && isValidationResponse(error.body)) {
+        setValidation(error.body);
+        return;
+      }
+
+      setValidation({
+        attemptedRows: 0,
+        dataset: variables.dataset,
+        fileErrors: [
+          {
+            code: 'upload_failed',
+            message: 'The import could not be completed.',
+          },
+        ],
+        filename: variables.file.name,
+        rows: [],
+        succeeded: false,
+      });
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['imports', 'recent'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['projectIdentification', 'setup'],
+      });
+    },
+    onSuccess: (response) => {
+      setValidation(null);
+      setSuccess(response);
+      setSelectedImportId(response.importLogId ?? null);
+      void queryClient.invalidateQueries({ queryKey: ['ad419Workflow'] });
+    },
+  });
+
+  const canUpload = Boolean(file) && !mutation.isPending;
+  const canMarkDone = ready && !completed && !markDonePending;
+
+  const handleUpload = () => {
+    if (!file || mutation.isPending) {
+      return;
+    }
+
+    const selectedFile = file;
+    clearInputFileSelection();
+    setValidation(null);
+    setSuccess(null);
+    setSelectedImportId(null);
+    mutation.mutate({ dataset, file: selectedFile });
+  };
+
+  return (
+    <div className="space-y-4">
+      {latestImport ? (
+        <RecentImportSummary
+          importLog={latestImport}
+          label={label}
+          onSelectImport={setSelectedImportId}
+          selected={latestImport.id === selectedImportId}
+        />
+      ) : (
+        <div className="rounded border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+          No import attempts found for {label}.
+        </div>
+      )}
+
+      {stale && staleReason ? (
+        <div className="alert alert-warning py-3 text-sm">
+          <span>{staleReason}</span>
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
+        <label className="form-control w-full">
+          <span className="label-text">Import file</span>
+          <input
+            accept=".csv,.xlsx"
+            className="file-input file-input-bordered w-full"
+            onChange={(event) => {
+              const selectedFile = event.target.files?.[0];
+              if (!selectedFile) {
+                return;
+              }
+
+              setFile(selectedFile);
+              setValidation(null);
+              setSuccess(null);
+            }}
+            onClick={(event) => {
+              event.currentTarget.value = '';
+            }}
+            ref={fileInputRef}
+            type="file"
+          />
+        </label>
+
+        <button
+          className="btn btn-outline"
+          disabled={!canUpload}
+          onClick={handleUpload}
+          type="button"
+        >
+          {mutation.isPending ? 'Uploading' : 'Upload'}
+        </button>
+
+        <button
+          className="btn btn-primary"
+          disabled={!canMarkDone}
+          onClick={onMarkDone}
+          type="button"
+        >
+          {markDonePending
+            ? 'Saving'
+            : completed
+              ? 'Done'
+              : ready
+                ? 'Mark done'
+                : 'Awaiting successful import'}
+        </button>
+      </div>
+
+      {selectedImportId !== null && (
+        <HistoricalImportDetails query={importDetailQuery} />
+      )}
+
+      {success && (
+        <div className="alert alert-success py-3 text-sm">
+          <span>
+            Imported {success.rowsImported.toLocaleString()} rows from{' '}
+            {success.filename}. Mark this checklist item done when you are
+            ready to use this import.
           </span>
         </div>
       )}
@@ -627,6 +810,10 @@ function getImportSummaries(
       lastImport: summary?.lastImport ?? null,
     };
   });
+}
+
+function getDatasetLabel(dataset: ImportDatasetId): string {
+  return datasetOptions.find((option) => option.id === dataset)?.label ?? dataset;
 }
 
 function getImportStatusPresentation(status: string) {

--- a/client/src/components/ProjectIdentificationSetupChecklist.tsx
+++ b/client/src/components/ProjectIdentificationSetupChecklist.tsx
@@ -1,0 +1,474 @@
+import {
+  confirmFiscalPeriod,
+  setChecklistItemCompletion,
+  type ProjectChecklistItem,
+  type ProjectIdentificationSetupResponse,
+} from '@/queries/projectIdentification.ts';
+import {
+  FlatFileImportChecklistItem,
+  type ImportDatasetId,
+} from '@/components/FlatFileImportPanel.tsx';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { fetchJson } from '@/lib/api.ts';
+
+interface PgmImportResponse {
+  reportDate: string;
+  rowsImported: number;
+}
+
+export function ProjectIdentificationSetupChecklist({
+  issueCount,
+  setup,
+}: {
+  issueCount: number | null;
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  const queryClient = useQueryClient();
+  const firstIncompleteId = useMemo(
+    () => setup.checklistItems.find((item) => !item.completed)?.id ?? null,
+    [setup.checklistItems]
+  );
+  const [openItemId, setOpenItemId] = useState<string | null>(
+    firstIncompleteId
+  );
+
+  const markCompletionMutation = useMutation({
+    mutationFn: ({
+      completed,
+      itemId,
+    }: {
+      completed: boolean;
+      itemId: string;
+    }) => setChecklistItemCompletion(itemId, completed),
+    onSuccess: (response) => {
+      queryClient.setQueryData(['projectIdentification', 'setup'], response);
+      setOpenItemId(findFirstIncompleteItemId(response));
+      void queryClient.invalidateQueries({ queryKey: ['projectList'] });
+    },
+  });
+
+  const fiscalMutation = useMutation({
+    mutationFn: confirmFiscalPeriod,
+    onSuccess: (response) => {
+      queryClient.setQueryData(['projectIdentification', 'setup'], response);
+      setOpenItemId(findFirstIncompleteItemId(response));
+      void queryClient.invalidateQueries({ queryKey: ['projectList'] });
+    },
+  });
+
+  const handleMarkDone = (itemId: string) => {
+    markCompletionMutation.mutate({ completed: true, itemId });
+  };
+
+  return (
+    <section className="workflow-panel">
+      <div className="workflow-panel__header">
+        <div>
+          <p>Setup checklist</p>
+          <h2>Load required data</h2>
+        </div>
+        <div className="min-w-40 space-y-2 text-right">
+          <div className="text-sm text-slate-500">
+            {setup.completedCount} of {setup.totalCount} complete
+          </div>
+          <progress
+            className="progress progress-neutral h-1.5 w-40"
+            max={setup.totalCount}
+            value={setup.completedCount}
+          />
+        </div>
+      </div>
+
+      <div className="divide-y divide-slate-200">
+        {setup.checklistItems.map((item) => {
+          const locked = item.status === 'locked';
+          const open = openItemId === item.id && !locked;
+          const pending =
+            markCompletionMutation.isPending &&
+            markCompletionMutation.variables?.itemId === item.id;
+
+          return (
+            <div
+              className={[
+                'checklist-item',
+                `checklist-item--${item.status}`,
+                open ? 'checklist-item--open' : undefined,
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              key={item.id}
+            >
+              <button
+                className="checklist-item__header"
+                disabled={locked}
+                onClick={() => setOpenItemId(open ? null : item.id)}
+                type="button"
+              >
+                <span className="checklist-item__bullet">
+                  {item.completed ? '✓' : item.number}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block font-semibold">{item.label}</span>
+                  <span className="block text-sm text-slate-500">
+                    {item.hint}
+                  </span>
+                </span>
+                <ChecklistMeta issueCount={issueCount} item={item} />
+                {!locked ? (
+                  <span
+                    aria-hidden="true"
+                    className={[
+                      'text-xl leading-none text-slate-500 transition',
+                      open ? 'rotate-90' : undefined,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                  >
+                    ›
+                  </span>
+                ) : null}
+              </button>
+
+              {open ? (
+                <div className="checklist-item__content">
+                  <ChecklistItemContent
+                    fiscalMutationPending={fiscalMutation.isPending}
+                    issueCount={issueCount}
+                    item={item}
+                    markDonePending={pending}
+                    onConfirmFiscalYear={(fiscalYear) =>
+                      fiscalMutation.mutate(fiscalYear)
+                    }
+                    onMarkDone={() => handleMarkDone(item.id)}
+                    setup={setup}
+                  />
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function ChecklistItemContent({
+  fiscalMutationPending,
+  issueCount,
+  item,
+  markDonePending,
+  onConfirmFiscalYear,
+  onMarkDone,
+  setup,
+}: {
+  fiscalMutationPending: boolean;
+  issueCount: number | null;
+  item: ProjectChecklistItem;
+  markDonePending: boolean;
+  onConfirmFiscalYear: (fiscalYear: string) => void;
+  onMarkDone: () => void;
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  if (item.kind === 'select') {
+    return (
+      <FiscalPeriodChecklistContent
+        item={item}
+        key={setup.fiscalYear}
+        onConfirmFiscalYear={onConfirmFiscalYear}
+        pending={fiscalMutationPending}
+        setup={setup}
+      />
+    );
+  }
+
+  if (item.kind === 'upload') {
+    return (
+      <FlatFileImportChecklistItem
+        completed={item.completed}
+        dataset={item.id as ImportDatasetId}
+        latestImport={item.latestImport}
+        markDonePending={markDonePending}
+        onMarkDone={onMarkDone}
+        ready={item.ready}
+        stale={item.stale}
+        staleReason={item.staleReason}
+      />
+    );
+  }
+
+  if (item.kind === 'import') {
+    return (
+      <PgmImportChecklistContent
+        item={item}
+        markDonePending={markDonePending}
+        onMarkDone={onMarkDone}
+        setup={setup}
+      />
+    );
+  }
+
+  if (item.kind === 'review') {
+    const issuesResolved = issueCount === 0;
+
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600">
+          {issueCount === null
+            ? 'Project issues are still being checked. Review can be marked complete after the project list loads.'
+            : issueCount > 0
+              ? `${issueCount.toLocaleString()} ${
+                  issueCount === 1 ? 'project needs' : 'projects need'
+                } review in the table below. Each issue must be resolved or explicitly accepted before finalizing.`
+              : 'No project issues were detected. You can mark this checklist item reviewed.'}
+        </p>
+        <button
+          className="btn btn-primary"
+          disabled={!issuesResolved || item.completed || markDonePending}
+          onClick={onMarkDone}
+          type="button"
+        >
+          {markDonePending
+            ? 'Saving'
+            : item.completed
+              ? 'Reviewed'
+              : 'Mark all reviewed'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-600">
+        Finalizing will be enabled when project issue acceptance and expense
+        pull behavior are implemented.
+      </p>
+      <button className="btn btn-primary" disabled type="button">
+        Finalize projects
+      </button>
+    </div>
+  );
+}
+
+function FiscalPeriodChecklistContent({
+  item,
+  onConfirmFiscalYear,
+  pending,
+  setup,
+}: {
+  item: ProjectChecklistItem;
+  onConfirmFiscalYear: (fiscalYear: string) => void;
+  pending: boolean;
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  const [selectedFiscalYear, setSelectedFiscalYear] = useState(
+    setup.fiscalYear
+  );
+  const selectedOption =
+    setup.fiscalPeriodOptions.find(
+      (option) => option.fiscalYear === selectedFiscalYear
+    ) ?? setup.fiscalPeriodOptions[0];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 lg:grid-cols-2">
+        <label className="form-control w-full">
+          <span className="label-text">Fiscal year</span>
+          <select
+            className="select select-bordered w-full"
+            onChange={(event) => setSelectedFiscalYear(event.target.value)}
+            value={selectedFiscalYear}
+          >
+            {setup.fiscalPeriodOptions.map((option) => (
+              <option key={option.fiscalYear} value={option.fiscalYear}>
+                {option.fiscalYear.replace('FY', 'FY:')}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="form-control w-full">
+          <span className="label-text">Period</span>
+          <select
+            className="select select-bordered w-full"
+            disabled
+            value={selectedOption?.label ?? ''}
+          >
+            <option>{selectedOption?.label ?? ''}</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          className="btn btn-primary"
+          disabled={pending}
+          onClick={() => onConfirmFiscalYear(selectedFiscalYear)}
+          type="button"
+        >
+          {pending ? 'Saving' : item.completed ? 'Change' : 'Confirm'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PgmImportChecklistContent({
+  item,
+  markDonePending,
+  onMarkDone,
+  setup,
+}: {
+  item: ProjectChecklistItem;
+  markDonePending: boolean;
+  onMarkDone: () => void;
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  const queryClient = useQueryClient();
+  const [result, setResult] = useState<PgmImportResponse | null>(null);
+  const mutation = useMutation({
+    mutationFn: () =>
+      fetchJson<PgmImportResponse>(
+        `/api/pgmprojects/import?reportDate=${encodeURIComponent(
+          setup.cycleEnd
+        )}`,
+        {
+          method: 'POST',
+        }
+      ),
+    onSuccess: (response) => {
+      setResult(response);
+      void queryClient.invalidateQueries({
+        queryKey: ['projectIdentification', 'setup'],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['projectList'] });
+    },
+  });
+  const rows = result?.rowsImported ?? item.source?.rows ?? null;
+  const importedAt = item.source?.completedAt;
+  const canMarkDone = item.ready && !item.completed && !markDonePending;
+
+  return (
+    <div className="space-y-4">
+      {rows ? (
+        <div className="rounded border border-slate-200 bg-slate-50 p-3 text-sm">
+          <div className="font-semibold">PGM Master Data</div>
+          <div className="mt-1 text-slate-600">
+            {rows.toLocaleString()} rows imported
+            {importedAt ? ` on ${formatDate(importedAt)}` : ''}.
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-slate-600">
+          Pulls AE Redshift PGM master data for the selected reporting cycle.
+        </p>
+      )}
+
+      {mutation.isError ? (
+        <div className="alert alert-error py-3 text-sm">
+          <span>PGM master data could not be imported.</span>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <button
+          className="btn btn-outline"
+          disabled={mutation.isPending}
+          onClick={() => mutation.mutate()}
+          type="button"
+        >
+          {mutation.isPending
+            ? 'Importing'
+            : item.ready
+              ? 'Re-import'
+              : 'Run import'}
+        </button>
+        <button
+          className="btn btn-primary"
+          disabled={!canMarkDone}
+          onClick={onMarkDone}
+          type="button"
+        >
+          {markDonePending
+            ? 'Saving'
+            : item.completed
+              ? 'Done'
+              : item.ready
+                ? 'Mark done'
+                : 'Awaiting import'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ChecklistMeta({
+  issueCount,
+  item,
+}: {
+  issueCount: number | null;
+  item: ProjectChecklistItem;
+}) {
+  if (item.kind === 'review') {
+    if (issueCount === null) {
+      return <span className="badge badge-neutral">Checking</span>;
+    }
+
+    return (
+      <span
+        className={
+          issueCount > 0 ? 'badge badge-warning' : 'badge badge-success'
+        }
+      >
+        {issueCount > 0 ? `${issueCount.toLocaleString()} issues` : 'No issues'}
+      </span>
+    );
+  }
+
+  if (item.kind === 'upload' && item.latestImport) {
+    const className =
+      item.latestImport.status === 'Succeeded'
+        ? 'badge badge-success'
+        : 'badge badge-error';
+    const rowCount =
+      item.latestImport.status === 'Succeeded'
+        ? item.latestImport.rowsImported
+        : item.latestImport.attemptedRows;
+
+    return (
+      <span className={className}>{rowCount?.toLocaleString() ?? 0} rows</span>
+    );
+  }
+
+  if (item.kind === 'import' && item.source?.rows) {
+    return (
+      <span className="badge badge-neutral">
+        {item.source.rows.toLocaleString()} rows
+      </span>
+    );
+  }
+
+  if (item.status === 'ready') {
+    return <span className="badge badge-info">Ready</span>;
+  }
+
+  if (item.status === 'stale') {
+    return <span className="badge badge-warning">Needs review</span>;
+  }
+
+  return null;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function findFirstIncompleteItemId(
+  setup: ProjectIdentificationSetupResponse
+): string | null {
+  return setup.checklistItems.find((item) => !item.completed)?.id ?? null;
+}

--- a/client/src/components/ProjectIdentificationSetupChecklist.tsx
+++ b/client/src/components/ProjectIdentificationSetupChecklist.tsx
@@ -371,6 +371,11 @@ function PgmImportChecklistContent({
         </div>
       ) : null}
 
+      <p className="text-sm font-medium text-amber-700">
+        This import may take several minutes. Do not reload your browser while it
+        runs.
+      </p>
+
       <div className="flex flex-wrap justify-end gap-2">
         <button
           className="btn btn-outline"

--- a/client/src/components/ProjectIdentificationStage.tsx
+++ b/client/src/components/ProjectIdentificationStage.tsx
@@ -136,6 +136,25 @@ function ProjectIdentificationStageContent({
         id: 'pi',
       },
       {
+        accessorFn: (row) => row.ucpEmployeeId ?? '',
+        cell: ({ row }) => displayValue(row.original.ucpEmployeeId),
+        header: 'UCP Employee ID',
+        id: 'ucpEmployeeId',
+        meta: {
+          cellClassName: 'whitespace-nowrap',
+          headerClassName: 'whitespace-nowrap',
+        },
+      },
+      {
+        accessorFn: (row) => row.ucPathName ?? '',
+        cell: ({ row }) => displayValue(row.original.ucPathName),
+        header: 'UCPath Name',
+        id: 'ucPathName',
+        meta: {
+          headerClassName: 'whitespace-nowrap',
+        },
+      },
+      {
         accessorFn: (row) => row.department ?? '',
         cell: ({ row }) => displayValue(row.original.department),
         header: 'Department',
@@ -255,7 +274,7 @@ function ProjectIdentificationStageContent({
               <DataTable
                 columns={columns}
                 data={visibleRows}
-                filterPlaceholder="Search project, accession, PI..."
+                filterPlaceholder="Search project, accession, person..."
                 initialState={{ pagination: { pageSize: 25 } }}
                 key={activeTab}
                 tableClassName="table-zebra table-sm"

--- a/client/src/components/ProjectIdentificationStage.tsx
+++ b/client/src/components/ProjectIdentificationStage.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { DataTable } from '@/shared/dataTable.tsx';
 import {
-  currentFiscalYear,
   projectListQueryOptions,
   type ProjectListRow,
   type ProjectListStatus,
@@ -9,6 +8,11 @@ import {
 } from '@/queries/projectList.ts';
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
+import {
+  projectIdentificationSetupQueryOptions,
+  type ProjectIdentificationSetupResponse,
+} from '@/queries/projectIdentification.ts';
+import { ProjectIdentificationSetupChecklist } from '@/components/ProjectIdentificationSetupChecklist.tsx';
 
 type ProjectListTab = 'issues' | 'clean' | 'all';
 
@@ -61,9 +65,41 @@ function sfnDistributionText(summary: ProjectListSummary): string {
 }
 
 export function ProjectIdentificationStage() {
-  const fiscalYear = currentFiscalYear();
+  const setupQuery = useQuery(projectIdentificationSetupQueryOptions());
+
+  if (setupQuery.isLoading) {
+    return <p>Loading project identification setup...</p>;
+  }
+
+  if (setupQuery.isError || !setupQuery.data) {
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load project setup</h2>
+          <p>The project identification checklist could not be loaded.</p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={setupQuery.isFetching}
+            onClick={() => void setupQuery.refetch()}
+            type="button"
+          >
+            {setupQuery.isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return <ProjectIdentificationStageContent setup={setupQuery.data} />;
+}
+
+function ProjectIdentificationStageContent({
+  setup,
+}: {
+  setup: ProjectIdentificationSetupResponse;
+}) {
   const { data, error, isError, isFetching, isLoading, refetch } = useQuery(
-    projectListQueryOptions(fiscalYear)
+    projectListQueryOptions(setup.fiscalYear)
   );
   const [activeTab, setActiveTab] = useState<ProjectListTab>('issues');
 
@@ -125,9 +161,11 @@ export function ProjectIdentificationStage() {
     []
   );
 
-  if (isLoading) {
-    return <p>Loading project list...</p>;
-  }
+  const pgmItem = setup.checklistItems.find(
+    (item) => item.id === 'pgm-master-data'
+  );
+  const projectListReady = pgmItem?.completed ?? false;
+  const issueCount = data?.summary.issuesToResolve ?? null;
 
   if (isError) {
     const message =
@@ -136,99 +174,125 @@ export function ProjectIdentificationStage() {
         : 'The project list could not be loaded.';
 
     return (
-      <div className="alert alert-error items-start" role="alert">
-        <div>
-          <h2 className="font-bold">Unable to load project list</h2>
-          <p>{message}</p>
-          <button
-            className="btn btn-sm mt-3"
-            disabled={isFetching}
-            onClick={() => void refetch()}
-            type="button"
-          >
-            {isFetching ? 'Retrying...' : 'Retry'}
-          </button>
+      <div className="workflow-stack">
+        <ProjectIdentificationSetupChecklist
+          issueCount={issueCount}
+          setup={setup}
+        />
+        <div className="alert alert-error items-start" role="alert">
+          <div>
+            <h2 className="font-bold">Unable to load project list</h2>
+            <p>{message}</p>
+            <button
+              className="btn btn-sm mt-3"
+              disabled={isFetching}
+              onClick={() => void refetch()}
+              type="button"
+            >
+              {isFetching ? 'Retrying...' : 'Retry'}
+            </button>
+          </div>
         </div>
       </div>
     );
   }
 
-  if (!data) {
-    return <p>Loading project list...</p>;
-  }
+  const visibleRows = data ? rowsForTab(data.rows, activeTab) : [];
 
-  const visibleRows = rowsForTab(data.rows, activeTab);
+  return (
+    <div className="workflow-stack">
+      {data ? <ProjectSummaryCards summary={data.summary} /> : null}
+
+      <ProjectIdentificationSetupChecklist
+        issueCount={issueCount}
+        setup={setup}
+      />
+
+      <div className="rounded border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-3 border-b border-slate-200 px-4 py-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-normal text-slate-500">
+              Reference &amp; Issue Resolution
+            </p>
+            <h2 className="text-lg font-bold tracking-normal text-slate-950">
+              Project list{data ? ` · ${data.counts.all}` : ''}
+            </h2>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-4">
+          {isLoading ? (
+            <p>Loading project list...</p>
+          ) : !projectListReady ? (
+            <div className="rounded border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-slate-600">
+              Project list will appear after PGM master data is imported and
+              marked done.
+            </div>
+          ) : data ? (
+            <>
+              <div className="tabs tabs-bordered" role="tablist">
+                {tabs.map((tab) => {
+                  const count = data.counts[tab.id];
+
+                  return (
+                    <button
+                      aria-selected={activeTab === tab.id}
+                      className={`tab ${
+                        activeTab === tab.id ? 'tab-active' : ''
+                      }`}
+                      key={tab.id}
+                      onClick={() => setActiveTab(tab.id)}
+                      role="tab"
+                      type="button"
+                    >
+                      {tab.label}
+                      <span className="badge badge-sm ml-2">{count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <DataTable
+                columns={columns}
+                data={visibleRows}
+                filterPlaceholder="Search project, accession, PI..."
+                initialState={{ pagination: { pageSize: 25 } }}
+                key={activeTab}
+                tableClassName="table-zebra table-sm"
+              />
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectSummaryCards({ summary }: { summary: ProjectListSummary }) {
   const summaryCards = [
-    ['Active NIFA', data.summary.activeNifa],
-    ['All NIFA', data.summary.allNifa],
-    ['PGM records', data.summary.pgmRecords],
-    ['ALN codes', data.summary.alnCodes],
-    ['Issues to resolve', data.summary.issuesToResolve],
-    ['SFN distribution', sfnDistributionText(data.summary)],
+    ['Active NIFA', summary.activeNifa],
+    ['All NIFA', summary.allNifa],
+    ['PGM records', summary.pgmRecords],
+    ['ALN codes', summary.alnCodes],
+    ['Issues to resolve', summary.issuesToResolve],
+    ['SFN distribution', sfnDistributionText(summary)],
   ];
 
   return (
-    <div className="rounded border border-slate-200 bg-white shadow-sm">
-      <div className="flex flex-col gap-3 border-b border-slate-200 px-4 py-4 lg:flex-row lg:items-center lg:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-normal text-slate-500">
-            Reference &amp; Issue Resolution
-          </p>
-          <h2 className="text-lg font-bold tracking-normal text-slate-950">
-            Project list · {data.counts.all}
-          </h2>
-        </div>
-        <button className="btn btn-primary" disabled type="button">
-          Finalize
-        </button>
-      </div>
-
-      <div className="space-y-4 p-4">
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
-          {summaryCards.map(([label, value]) => (
-            <div
-              className="rounded border border-slate-200 bg-slate-50 p-3"
-              key={label}
-            >
-              <div className="text-xs font-semibold uppercase text-slate-500">
-                {label}
-              </div>
-              <div className="mt-1 text-lg font-bold text-slate-950">
-                {value}
-              </div>
+    <section className="rounded border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        {summaryCards.map(([label, value]) => (
+          <div
+            className="rounded border border-slate-200 bg-slate-50 p-3"
+            key={label}
+          >
+            <div className="text-xs font-semibold uppercase text-slate-500">
+              {label}
             </div>
-          ))}
-        </div>
-
-        <div className="tabs tabs-bordered" role="tablist">
-          {tabs.map((tab) => {
-            const count = data.counts[tab.id];
-
-            return (
-              <button
-                aria-selected={activeTab === tab.id}
-                className={`tab ${activeTab === tab.id ? 'tab-active' : ''}`}
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                role="tab"
-                type="button"
-              >
-                {tab.label}
-                <span className="badge badge-sm ml-2">{count}</span>
-              </button>
-            );
-          })}
-        </div>
-
-        <DataTable
-          columns={columns}
-          data={visibleRows}
-          filterPlaceholder="Search project, accession, PI..."
-          initialState={{ pagination: { pageSize: 25 } }}
-          key={activeTab}
-          tableClassName="table-zebra table-sm"
-        />
+            <div className="mt-1 text-lg font-bold text-slate-950">{value}</div>
+          </div>
+        ))}
       </div>
-    </div>
+    </section>
   );
 }

--- a/client/src/components/ProjectIdentificationStage.tsx
+++ b/client/src/components/ProjectIdentificationStage.tsx
@@ -136,10 +136,10 @@ function ProjectIdentificationStageContent({
         id: 'pi',
       },
       {
-        accessorFn: (row) => row.orgr ?? '',
-        cell: ({ row }) => displayValue(row.original.orgr),
-        header: 'ORGR',
-        id: 'orgr',
+        accessorFn: (row) => row.department ?? '',
+        cell: ({ row }) => displayValue(row.original.department),
+        header: 'Department',
+        id: 'department',
       },
       {
         accessorFn: (row) => row.sfn ?? '',

--- a/client/src/components/ProjectIdentificationStage.tsx
+++ b/client/src/components/ProjectIdentificationStage.tsx
@@ -62,7 +62,9 @@ function sfnDistributionText(summary: ProjectListSummary): string {
 
 export function ProjectIdentificationStage() {
   const fiscalYear = currentFiscalYear();
-  const { data, isLoading } = useQuery(projectListQueryOptions(fiscalYear));
+  const { data, error, isError, isFetching, isLoading, refetch } = useQuery(
+    projectListQueryOptions(fiscalYear)
+  );
   const [activeTab, setActiveTab] = useState<ProjectListTab>('issues');
 
   const columns = useMemo<ColumnDef<ProjectListRow>[]>(
@@ -123,7 +125,35 @@ export function ProjectIdentificationStage() {
     []
   );
 
-  if (isLoading || !data) {
+  if (isLoading) {
+    return <p>Loading project list...</p>;
+  }
+
+  if (isError) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'The project list could not be loaded.';
+
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load project list</h2>
+          <p>{message}</p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={isFetching}
+            onClick={() => void refetch()}
+            type="button"
+          >
+            {isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
     return <p>Loading project list...</p>;
   }
 
@@ -138,11 +168,15 @@ export function ProjectIdentificationStage() {
   ];
 
   return (
-    <div className="workflow-panel">
-      <div className="workflow-panel__header">
+    <div className="rounded border border-slate-200 bg-white shadow-sm">
+      <div className="flex flex-col gap-3 border-b border-slate-200 px-4 py-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <p>Reference &amp; Issue Resolution</p>
-          <h2>Project list · {data.counts.all}</h2>
+          <p className="text-xs font-semibold uppercase tracking-normal text-slate-500">
+            Reference &amp; Issue Resolution
+          </p>
+          <h2 className="text-lg font-bold tracking-normal text-slate-950">
+            Project list · {data.counts.all}
+          </h2>
         </div>
         <button className="btn btn-primary" disabled type="button">
           Finalize
@@ -152,11 +186,16 @@ export function ProjectIdentificationStage() {
       <div className="space-y-4 p-4">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
           {summaryCards.map(([label, value]) => (
-            <div className="rounded border border-slate-200 bg-slate-50 p-3" key={label}>
+            <div
+              className="rounded border border-slate-200 bg-slate-50 p-3"
+              key={label}
+            >
               <div className="text-xs font-semibold uppercase text-slate-500">
                 {label}
               </div>
-              <div className="mt-1 text-lg font-bold text-slate-950">{value}</div>
+              <div className="mt-1 text-lg font-bold text-slate-950">
+                {value}
+              </div>
             </div>
           ))}
         </div>

--- a/client/src/components/ProjectIdentificationStage.tsx
+++ b/client/src/components/ProjectIdentificationStage.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from 'react';
+import { DataTable } from '@/shared/dataTable.tsx';
+import {
+  currentFiscalYear,
+  projectListQueryOptions,
+  type ProjectListRow,
+  type ProjectListStatus,
+  type ProjectListSummary,
+} from '@/queries/projectList.ts';
+import { useQuery } from '@tanstack/react-query';
+import type { ColumnDef } from '@tanstack/react-table';
+
+type ProjectListTab = 'issues' | 'clean' | 'all';
+
+const tabs: { id: ProjectListTab; label: string }[] = [
+  { id: 'issues', label: 'Issues' },
+  { id: 'clean', label: 'Clean' },
+  { id: 'all', label: 'All' },
+];
+
+function displayValue(value: string | null): string {
+  return value && value.trim() ? value : '-';
+}
+
+function displayStatus(status: ProjectListStatus): string {
+  return status === '204 outside college' ? '204 outside CAES' : status;
+}
+
+function statusClassName(status: ProjectListStatus): string {
+  if (status === 'Clean') {
+    return 'badge badge-success badge-outline';
+  }
+
+  if (status === '204 outside college' || status === 'SFN mismatch') {
+    return 'badge badge-warning';
+  }
+
+  return 'badge badge-error badge-outline';
+}
+
+function rowsForTab(rows: ProjectListRow[], tab: ProjectListTab) {
+  if (tab === 'issues') {
+    return rows.filter((row) => row.status !== 'Clean');
+  }
+
+  if (tab === 'clean') {
+    return rows.filter((row) => row.status === 'Clean');
+  }
+
+  return rows;
+}
+
+function sfnDistributionText(summary: ProjectListSummary): string {
+  if (summary.sfnDistribution.length === 0) {
+    return '-';
+  }
+
+  return summary.sfnDistribution
+    .map((item) => `${item.sfn}: ${item.count}`)
+    .join(' / ');
+}
+
+export function ProjectIdentificationStage() {
+  const fiscalYear = currentFiscalYear();
+  const { data, isLoading } = useQuery(projectListQueryOptions(fiscalYear));
+  const [activeTab, setActiveTab] = useState<ProjectListTab>('issues');
+
+  const columns = useMemo<ColumnDef<ProjectListRow>[]>(
+    () => [
+      {
+        accessorFn: (row) => row.nifaProject ?? '',
+        cell: ({ row }) => displayValue(row.original.nifaProject),
+        header: 'NIFA Project',
+        id: 'nifaProject',
+      },
+      {
+        accessorFn: (row) => row.accession ?? '',
+        cell: ({ row }) => displayValue(row.original.accession),
+        header: 'Accession',
+        id: 'accession',
+      },
+      {
+        accessorFn: (row) => row.awardNumber ?? '',
+        cell: ({ row }) => displayValue(row.original.awardNumber),
+        header: 'Award #',
+        id: 'awardNumber',
+      },
+      {
+        accessorFn: (row) => row.ae ?? '',
+        cell: ({ row }) => displayValue(row.original.ae),
+        header: 'AE',
+        id: 'ae',
+      },
+      {
+        accessorFn: (row) => row.pi ?? '',
+        cell: ({ row }) => displayValue(row.original.pi),
+        header: 'PI',
+        id: 'pi',
+      },
+      {
+        accessorFn: (row) => row.orgr ?? '',
+        cell: ({ row }) => displayValue(row.original.orgr),
+        header: 'ORGR',
+        id: 'orgr',
+      },
+      {
+        accessorFn: (row) => row.sfn ?? '',
+        cell: ({ row }) => displayValue(row.original.sfn),
+        header: 'SFN',
+        id: 'sfn',
+      },
+      {
+        accessorFn: (row) => displayStatus(row.status),
+        cell: ({ row }) => (
+          <span className={statusClassName(row.original.status)}>
+            {displayStatus(row.original.status)}
+          </span>
+        ),
+        header: 'Status',
+        id: 'status',
+      },
+    ],
+    []
+  );
+
+  if (isLoading || !data) {
+    return <p>Loading project list...</p>;
+  }
+
+  const visibleRows = rowsForTab(data.rows, activeTab);
+  const summaryCards = [
+    ['Active NIFA', data.summary.activeNifa],
+    ['All NIFA', data.summary.allNifa],
+    ['PGM records', data.summary.pgmRecords],
+    ['ALN codes', data.summary.alnCodes],
+    ['Issues to resolve', data.summary.issuesToResolve],
+    ['SFN distribution', sfnDistributionText(data.summary)],
+  ];
+
+  return (
+    <div className="workflow-panel">
+      <div className="workflow-panel__header">
+        <div>
+          <p>Reference &amp; Issue Resolution</p>
+          <h2>Project list · {data.counts.all}</h2>
+        </div>
+        <button className="btn btn-primary" disabled type="button">
+          Finalize
+        </button>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          {summaryCards.map(([label, value]) => (
+            <div className="rounded border border-slate-200 bg-slate-50 p-3" key={label}>
+              <div className="text-xs font-semibold uppercase text-slate-500">
+                {label}
+              </div>
+              <div className="mt-1 text-lg font-bold text-slate-950">{value}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="tabs tabs-bordered" role="tablist">
+          {tabs.map((tab) => {
+            const count = data.counts[tab.id];
+
+            return (
+              <button
+                aria-selected={activeTab === tab.id}
+                className={`tab ${activeTab === tab.id ? 'tab-active' : ''}`}
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                role="tab"
+                type="button"
+              >
+                {tab.label}
+                <span className="badge badge-sm ml-2">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <DataTable
+          columns={columns}
+          data={visibleRows}
+          filterPlaceholder="Search project, accession, PI..."
+          initialState={{ pagination: { pageSize: 25 } }}
+          key={activeTab}
+          tableClassName="table-zebra table-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -102,4 +102,39 @@
   .workflow-panel__actions {
     @apply flex flex-wrap items-center gap-2;
   }
+
+  .checklist-item {
+    @apply bg-white;
+  }
+
+  .checklist-item--active,
+  .checklist-item--ready,
+  .checklist-item--stale {
+    @apply bg-slate-50;
+  }
+
+  .checklist-item__header {
+    @apply flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .checklist-item__bullet {
+    @apply flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-300 text-sm font-bold text-slate-700;
+  }
+
+  .checklist-item--done .checklist-item__bullet {
+    @apply border-slate-950 bg-slate-950 text-white;
+  }
+
+  .checklist-item--active .checklist-item__bullet,
+  .checklist-item--ready .checklist-item__bullet {
+    @apply border-sky-700 bg-sky-700 text-white;
+  }
+
+  .checklist-item--stale .checklist-item__bullet {
+    @apply border-amber-500 bg-amber-500 text-white;
+  }
+
+  .checklist-item__content {
+    @apply border-t border-dashed border-slate-200 px-4 py-4 sm:pl-14;
+  }
 }

--- a/client/src/queries/projectIdentification.ts
+++ b/client/src/queries/projectIdentification.ts
@@ -1,0 +1,106 @@
+import { fetchJson } from '@/lib/api.ts';
+import { queryOptions } from '@tanstack/react-query';
+
+export type ChecklistStatus = 'active' | 'done' | 'locked' | 'ready' | 'stale';
+
+export type ChecklistKind = 'action' | 'import' | 'review' | 'select' | 'upload';
+
+export interface RecentImportResponse {
+  attemptedRows: number;
+  dataset: string;
+  filename: string;
+  id: number;
+  importedAt: string;
+  rowsImported?: number | null;
+  status: string;
+  uploadedByEmail?: string | null;
+  uploadedByName?: string | null;
+  validationStats?: ImportValidationStatsResponse | null;
+}
+
+export interface ImportValidationStatsResponse {
+  errorCount: number;
+  fileErrorCount: number;
+  rowCount: number;
+  rowsWithErrors: number;
+}
+
+export interface ChecklistSource {
+  completedAt?: string | null;
+  importLogId?: number | null;
+  key?: string | null;
+  rows?: number | null;
+}
+
+export interface ProjectChecklistItem {
+  completed: boolean;
+  hint: string;
+  id: string;
+  kind: ChecklistKind;
+  label: string;
+  latestImport?: RecentImportResponse | null;
+  number: number;
+  ready: boolean;
+  source?: ChecklistSource | null;
+  stale: boolean;
+  staleReason?: string | null;
+  status: ChecklistStatus;
+}
+
+export interface FiscalPeriodOption {
+  cycleEnd: string;
+  cycleStart: string;
+  fiscalYear: string;
+  label: string;
+}
+
+export interface ProjectIdentificationSetupResponse {
+  checklistItems: ProjectChecklistItem[];
+  completedCount: number;
+  cycleEnd: string;
+  cycleStart: string;
+  fiscalPeriodOptions: FiscalPeriodOption[];
+  fiscalYear: string;
+  totalCount: number;
+  workflowRunId: number;
+}
+
+export const projectIdentificationSetupQueryOptions = () =>
+  queryOptions({
+    queryFn: ({ signal }) =>
+      fetchJson<ProjectIdentificationSetupResponse>(
+        '/api/projectidentification/setup',
+        {},
+        signal
+      ),
+    queryKey: ['projectIdentification', 'setup'] as const,
+  });
+
+export async function confirmFiscalPeriod(fiscalYear: string) {
+  return fetchJson<ProjectIdentificationSetupResponse>(
+    '/api/projectidentification/fiscal-period',
+    {
+      body: JSON.stringify({ fiscalYear }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PUT',
+    }
+  );
+}
+
+export async function setChecklistItemCompletion(
+  itemId: string,
+  completed: boolean
+) {
+  return fetchJson<ProjectIdentificationSetupResponse>(
+    `/api/projectidentification/checklist/${encodeURIComponent(itemId)}`,
+    {
+      body: JSON.stringify({ completed }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PUT',
+    }
+  );
+}

--- a/client/src/queries/projectList.ts
+++ b/client/src/queries/projectList.ts
@@ -1,0 +1,68 @@
+import { fetchJson } from '@/lib/api.ts';
+import { queryOptions } from '@tanstack/react-query';
+
+export type ProjectListStatus =
+  | '204 outside college'
+  | 'Clean'
+  | 'Expired'
+  | 'No PGM match'
+  | 'Not in All Projects'
+  | 'SFN mismatch'
+  | string;
+
+export interface ProjectListRow {
+  accession: string | null;
+  ae: string | null;
+  awardNumber: string | null;
+  nifaProject: string | null;
+  orgr: string | null;
+  pi: string | null;
+  sfn: string | null;
+  status: ProjectListStatus;
+}
+
+export interface ProjectListCounts {
+  all: number;
+  clean: number;
+  issues: number;
+}
+
+export interface SfnDistribution {
+  count: number;
+  sfn: string;
+}
+
+export interface ProjectListSummary {
+  activeNifa: number;
+  allNifa: number;
+  alnCodes: number;
+  issuesToResolve: number;
+  pgmRecords: number;
+  sfnDistribution: SfnDistribution[];
+}
+
+export interface ProjectListResponse {
+  counts: ProjectListCounts;
+  cycleEnd: string;
+  cycleStart: string;
+  fiscalYear: string;
+  rows: ProjectListRow[];
+  summary: ProjectListSummary;
+}
+
+export function currentFiscalYear(date = new Date()): string {
+  const calendarYear = date.getFullYear();
+  const fiscalYear = date.getMonth() >= 9 ? calendarYear + 1 : calendarYear;
+  return `FY${String(fiscalYear % 100).padStart(2, '0')}`;
+}
+
+export const projectListQueryOptions = (fiscalYear = currentFiscalYear()) =>
+  queryOptions({
+    queryFn: ({ signal }) =>
+      fetchJson<ProjectListResponse>(
+        `/api/projectlist?fy=${encodeURIComponent(fiscalYear)}`,
+        {},
+        signal
+      ),
+    queryKey: ['projectList', fiscalYear] as const,
+  });

--- a/client/src/queries/projectList.ts
+++ b/client/src/queries/projectList.ts
@@ -15,7 +15,7 @@ export interface ProjectListRow {
   ae: string | null;
   awardNumber: string | null;
   nifaProject: string | null;
-  orgr: string | null;
+  department: string | null;
   pi: string | null;
   sfn: string | null;
   status: ProjectListStatus;

--- a/client/src/queries/projectList.ts
+++ b/client/src/queries/projectList.ts
@@ -14,11 +14,13 @@ export interface ProjectListRow {
   accession: string | null;
   ae: string | null;
   awardNumber: string | null;
-  nifaProject: string | null;
   department: string | null;
+  nifaProject: string | null;
   pi: string | null;
   sfn: string | null;
   status: ProjectListStatus;
+  ucPathName: string | null;
+  ucpEmployeeId: string | null;
 }
 
 export interface ProjectListCounts {

--- a/client/src/routes/(authenticated)/workflow.$stageId.tsx
+++ b/client/src/routes/(authenticated)/workflow.$stageId.tsx
@@ -6,7 +6,6 @@ import { workflowSnapshotQueryOptions } from '@/queries.ts';
 import { DataClassificationStage } from '@/components/dataClassification/DataClassificationStage.tsx';
 import { ProjectIdentificationStage } from '@/components/ProjectIdentificationStage.tsx';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
-import { FlatFileImportPanel } from '@/components/FlatFileImportPanel.tsx';
 import { WorkflowShell } from '@/components/WorkflowShell.tsx';
 import type { WorkflowStageId } from '@/types.ts';
 import type { RouterContext } from '@/main.tsx';
@@ -49,12 +48,7 @@ function WorkflowStageRoute() {
     <WorkflowShell snapshot={snapshot} stage={stage}>
       <div className="workflow-stack">
         {workflowStageId === 'project-identification' ? (
-          <>
-            <SectionPanel title="Load required data">
-              <FlatFileImportPanel />
-            </SectionPanel>
-            <ProjectIdentificationStage />
-          </>
+          <ProjectIdentificationStage />
         ) : workflowStageId === 'data-classification' ? (
           <DataClassificationStage />
         ) : (

--- a/client/src/routes/(authenticated)/workflow.$stageId.tsx
+++ b/client/src/routes/(authenticated)/workflow.$stageId.tsx
@@ -4,6 +4,7 @@ import {
 } from '@/mockData.ts';
 import { workflowSnapshotQueryOptions } from '@/queries.ts';
 import { DataClassificationStage } from '@/components/dataClassification/DataClassificationStage.tsx';
+import { ProjectIdentificationStage } from '@/components/ProjectIdentificationStage.tsx';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
 import { FlatFileImportPanel } from '@/components/FlatFileImportPanel.tsx';
 import { WorkflowShell } from '@/components/WorkflowShell.tsx';
@@ -48,9 +49,12 @@ function WorkflowStageRoute() {
     <WorkflowShell snapshot={snapshot} stage={stage}>
       <div className="workflow-stack">
         {workflowStageId === 'project-identification' ? (
-          <SectionPanel title="Load required data">
-            <FlatFileImportPanel />
-          </SectionPanel>
+          <>
+            <SectionPanel title="Load required data">
+              <FlatFileImportPanel />
+            </SectionPanel>
+            <ProjectIdentificationStage />
+          </>
         ) : workflowStageId === 'data-classification' ? (
           <DataClassificationStage />
         ) : (

--- a/client/src/test/components/FlatFileImportPanel.test.tsx
+++ b/client/src/test/components/FlatFileImportPanel.test.tsx
@@ -601,11 +601,11 @@ describe('FlatFileImportPanel', () => {
                 ],
                 errors: [],
                 rowNum: 2,
-                values: {
-                  ProjectNumber: 'PRJ-1',
-                  AccessionNumber: 'A-2',
-                  OrganizationName: '',
-                },
+                values: Object.fromEntries([
+                  ['ProjectNumber', 'PRJ-1'],
+                  ['AccessionNumber', 'A-2'],
+                  ['OrganizationName', ''],
+                ]),
               },
             ],
             succeeded: false,

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -27,7 +27,7 @@ const projectListResponse = {
       ae: 'K1234',
       awardNumber: '2025-111',
       nifaProject: 'CA-A-111-H',
-      orgr: 'ATM',
+      department: 'ATM',
       pi: 'Larkspur, S.',
       sfn: '201',
       status: 'Clean',
@@ -37,7 +37,7 @@ const projectListResponse = {
       ae: 'K2222',
       awardNumber: '2025-222',
       nifaProject: 'CA-B-222-CG',
-      orgr: 'ANS',
+      department: 'ANS',
       pi: 'Okonkwo, Y.',
       sfn: '204',
       status: '204 outside college',
@@ -47,7 +47,7 @@ const projectListResponse = {
       ae: null,
       awardNumber: '2025-333',
       nifaProject: 'CA-C-333-CG',
-      orgr: 'VEN',
+      department: 'VEN',
       pi: 'Naidoo, T.',
       sfn: '204',
       status: 'No PGM match',
@@ -272,7 +272,7 @@ describe('AD419 workflow routes', () => {
         screen.getByRole('columnheader', { name: 'PI' })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('columnheader', { name: 'ORGR' })
+        screen.getByRole('columnheader', { name: 'Department' })
       ).toBeInTheDocument();
       expect(
         screen.getByRole('columnheader', { name: 'SFN' })

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -66,6 +66,143 @@ const projectListResponse = {
   },
 };
 
+const setupResponse = {
+  checklistItems: [
+    {
+      completed: true,
+      hint: 'Set the reporting cycle',
+      id: 'fiscal-period',
+      kind: 'select',
+      label: 'Confirm Fiscal Period',
+      number: 1,
+      ready: true,
+      source: null,
+      stale: false,
+      staleReason: null,
+      status: 'done',
+    },
+    {
+      completed: true,
+      hint: 'ANR - all NIFA projects across UC campuses',
+      id: 'all-projects',
+      kind: 'upload',
+      label: 'Upload All Projects List',
+      latestImport: {
+        attemptedRows: 42,
+        dataset: 'all-projects',
+        filename: 'all-projects.csv',
+        id: 1,
+        importedAt: '2026-06-01T12:00:00Z',
+        rowsImported: 42,
+        status: 'Succeeded',
+      },
+      number: 2,
+      ready: true,
+      source: { completedAt: '2026-06-01T12:00:00Z', importLogId: 1, rows: 42 },
+      stale: false,
+      staleReason: null,
+      status: 'done',
+    },
+    {
+      completed: true,
+      hint: 'ANR - CAES projects required to report',
+      id: 'active-projects',
+      kind: 'upload',
+      label: 'Upload Active Project List',
+      latestImport: {
+        attemptedRows: 25,
+        dataset: 'active-projects',
+        filename: 'active-projects.csv',
+        id: 2,
+        importedAt: '2026-06-01T12:01:00Z',
+        rowsImported: 25,
+        status: 'Succeeded',
+      },
+      number: 3,
+      ready: true,
+      source: { completedAt: '2026-06-01T12:01:00Z', importLogId: 2, rows: 25 },
+      stale: false,
+      staleReason: null,
+      status: 'done',
+    },
+    {
+      completed: true,
+      hint: 'assistancelisting.usaspending.gov - updated weekly',
+      id: 'assistance-listing-numbers',
+      kind: 'upload',
+      label: 'Upload CFDA / ALN Data',
+      latestImport: {
+        attemptedRows: 7,
+        dataset: 'assistance-listing-numbers',
+        filename: 'aln.csv',
+        id: 3,
+        importedAt: '2026-06-01T12:02:00Z',
+        rowsImported: 7,
+        status: 'Succeeded',
+      },
+      number: 4,
+      ready: true,
+      source: { completedAt: '2026-06-01T12:02:00Z', importLogId: 3, rows: 7 },
+      stale: false,
+      staleReason: null,
+      status: 'done',
+    },
+    {
+      completed: true,
+      hint: 'AE Redshift - ae_dwh.pgm_master_data',
+      id: 'pgm-master-data',
+      kind: 'import',
+      label: 'Import PGM Master Data',
+      number: 5,
+      ready: true,
+      source: { completedAt: '2026-06-01T12:03:00Z', key: 'pgm', rows: 18 },
+      stale: false,
+      staleReason: null,
+      status: 'done',
+    },
+    {
+      completed: false,
+      hint: 'Review flagged projects below',
+      id: 'resolve-project-issues',
+      kind: 'review',
+      label: 'Resolve Project Issues',
+      number: 6,
+      ready: true,
+      source: null,
+      stale: false,
+      staleReason: null,
+      status: 'active',
+    },
+    {
+      completed: false,
+      hint: 'Locks project data, triggers full expense pull',
+      id: 'finalize-projects',
+      kind: 'action',
+      label: 'Finalize Projects',
+      number: 7,
+      ready: false,
+      source: null,
+      stale: false,
+      staleReason: null,
+      status: 'locked',
+    },
+  ],
+  completedCount: 5,
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  fiscalPeriodOptions: [
+    {
+      cycleEnd: '2026-09-30',
+      cycleStart: '2025-10-01',
+      fiscalYear: 'FY26',
+      label: 'FY:26 - Oct 2025 - Sep 2026',
+    },
+  ],
+  fiscalYear: 'FY26',
+  totalCount: 7,
+  workflowRunId: 1,
+};
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -83,6 +220,9 @@ describe('AD419 workflow routes', () => {
       http.get('/api/imports/recent', () => {
         return HttpResponse.json([]);
       }),
+      http.get('/api/projectidentification/setup', () => {
+        return HttpResponse.json(setupResponse);
+      }),
       http.get('/api/projectlist', ({ request }) => {
         requestedFy = new URL(request.url).searchParams.get('fy');
         return HttpResponse.json(projectListResponse);
@@ -99,8 +239,10 @@ describe('AD419 workflow routes', () => {
       expect(
         await screen.findByRole('heading', { name: 'Load required data' })
       ).toBeInTheDocument();
-      expect(screen.getByLabelText('Dataset')).toBeInTheDocument();
-      expect(screen.getByLabelText('Import file')).toBeInTheDocument();
+      expect(screen.getByText('5 of 7 complete')).toBeInTheDocument();
+      expect(screen.getByText('Confirm Fiscal Period')).toBeInTheDocument();
+      expect(screen.getByText('Upload All Projects List')).toBeInTheDocument();
+      expect(screen.getByText('Import PGM Master Data')).toBeInTheDocument();
       expect(
         await screen.findByRole('heading', { name: 'Project list · 3' })
       ).toBeInTheDocument();
@@ -139,7 +281,6 @@ describe('AD419 workflow routes', () => {
         screen.getByRole('columnheader', { name: 'Status' })
       ).toBeInTheDocument();
       expect(screen.getByText('204 outside CAES')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Finalize' })).toBeDisabled();
 
       await waitFor(() => {
         expect(router.state.location.pathname).toBe(
@@ -163,6 +304,9 @@ describe('AD419 workflow routes', () => {
       }),
       http.get('/api/imports/recent', () => {
         return HttpResponse.json([]);
+      }),
+      http.get('/api/projectidentification/setup', () => {
+        return HttpResponse.json(setupResponse);
       }),
       http.get('/api/projectlist', () => {
         return HttpResponse.json(projectListResponse);
@@ -208,6 +352,9 @@ describe('AD419 workflow routes', () => {
       }),
       http.get('/api/imports/recent', () => {
         return HttpResponse.json([]);
+      }),
+      http.get('/api/projectidentification/setup', () => {
+        return HttpResponse.json(setupResponse);
       }),
       http.get('/api/projectlist', () => {
         projectListRequests += 1;

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -26,31 +26,37 @@ const projectListResponse = {
       accession: '1053852',
       ae: 'K1234',
       awardNumber: '2025-111',
-      nifaProject: 'CA-A-111-H',
       department: 'ATM',
+      nifaProject: 'CA-A-111-H',
       pi: 'Larkspur, S.',
       sfn: '201',
       status: 'Clean',
+      ucPathName: 'Larkspur, Sasha',
+      ucpEmployeeId: '10000001',
     },
     {
       accession: '1055356',
       ae: 'K2222',
       awardNumber: '2025-222',
-      nifaProject: 'CA-B-222-CG',
       department: 'ANS',
+      nifaProject: 'CA-B-222-CG',
       pi: 'Okonkwo, Y.',
       sfn: '204',
       status: '204 outside college',
+      ucPathName: 'Okonkwo, Yara',
+      ucpEmployeeId: '10000002',
     },
     {
       accession: '1078258',
       ae: null,
       awardNumber: '2025-333',
-      nifaProject: 'CA-C-333-CG',
       department: 'VEN',
+      nifaProject: 'CA-C-333-CG',
       pi: 'Naidoo, T.',
       sfn: '204',
       status: 'No PGM match',
+      ucPathName: 'Naidoo, Talia',
+      ucpEmployeeId: '10000003',
     },
   ],
   summary: {
@@ -272,6 +278,12 @@ describe('AD419 workflow routes', () => {
         screen.getByRole('columnheader', { name: 'PI' })
       ).toBeInTheDocument();
       expect(
+        screen.getByRole('columnheader', { name: 'UCP Employee ID' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'UCPath Name' })
+      ).toBeInTheDocument();
+      expect(
         screen.getByRole('columnheader', { name: 'Department' })
       ).toBeInTheDocument();
       expect(
@@ -327,14 +339,22 @@ describe('AD419 workflow routes', () => {
 
       await user.click(screen.getByRole('tab', { name: /all\s*3/i }));
       expect(await screen.findByText('Naidoo, T.')).toBeInTheDocument();
-      await user.type(
-        screen.getByPlaceholderText('Search project, accession, PI...'),
-        '1078258'
+      const searchInput = screen.getByPlaceholderText(
+        'Search project, accession, person...'
       );
+
+      await user.type(searchInput, '1078258');
 
       expect(screen.getByText('Naidoo, T.')).toBeInTheDocument();
       expect(screen.queryByText('Okonkwo, Y.')).not.toBeInTheDocument();
       expect(screen.queryByText('Larkspur, S.')).not.toBeInTheDocument();
+
+      await user.clear(searchInput);
+      await user.type(searchInput, '10000002');
+
+      expect(screen.getByText('Okonkwo, Y.')).toBeInTheDocument();
+      expect(screen.getByText('Okonkwo, Yara')).toBeInTheDocument();
+      expect(screen.queryByText('Naidoo, T.')).not.toBeInTheDocument();
     } finally {
       cleanup();
     }

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -106,19 +106,38 @@ describe('AD419 workflow routes', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('Active NIFA')).toBeInTheDocument();
       expect(screen.getByText('Issues to resolve')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /issues\s*2/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
       expect(
-        screen.getByRole('tab', { name: /issues\s*2/i })
-      ).toHaveAttribute('aria-selected', 'true');
-      expect(screen.getByRole('tab', { name: /clean\s*1/i })).toBeInTheDocument();
+        screen.getByRole('tab', { name: /clean\s*1/i })
+      ).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /all\s*3/i })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'NIFA Project' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'Accession' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'Award #' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'AE' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'PI' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'ORGR' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'SFN' })).toBeInTheDocument();
-      expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'NIFA Project' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Accession' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Award #' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'AE' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'PI' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'ORGR' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'SFN' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Status' })
+      ).toBeInTheDocument();
       expect(screen.getByText('204 outside CAES')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Finalize' })).toBeDisabled();
 
@@ -172,6 +191,58 @@ describe('AD419 workflow routes', () => {
       expect(screen.getByText('Naidoo, T.')).toBeInTheDocument();
       expect(screen.queryByText('Okonkwo, Y.')).not.toBeInTheDocument();
       expect(screen.queryByText('Larkspur, S.')).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows project list errors and retries the query', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00-07:00'));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let projectListRequests = 0;
+
+    server.use(
+      http.get('/api/user/me', () => {
+        return HttpResponse.json(mockUser);
+      }),
+      http.get('/api/imports/recent', () => {
+        return HttpResponse.json([]);
+      }),
+      http.get('/api/projectlist', () => {
+        projectListRequests += 1;
+
+        if (projectListRequests === 1) {
+          return HttpResponse.json(
+            { message: 'Project list unavailable.' },
+            { status: 500 }
+          );
+        }
+
+        return HttpResponse.json(projectListResponse);
+      })
+    );
+
+    const { cleanup } = renderRoute({
+      initialPath: '/workflow/project-identification',
+    });
+
+    try {
+      expect(
+        await screen.findByRole('heading', {
+          name: 'Unable to load project list',
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Loading project list...')
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Project list · 3' })
+      ).toBeInTheDocument();
+      expect(projectListRequests).toBe(2);
     } finally {
       cleanup();
     }

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { screen, waitFor } from '@testing-library/react';
 import { server } from '@/test/mswUtils.ts';
 import { renderRoute } from '@/test/routerUtils.tsx';
+import { userEvent } from '@testing-library/user-event';
 
 const mockUser = {
   email: 'shannon@example.edu',
@@ -11,14 +12,80 @@ const mockUser = {
   roles: ['User'],
 };
 
+const projectListResponse = {
+  counts: {
+    all: 3,
+    clean: 1,
+    issues: 2,
+  },
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  fiscalYear: 'FY26',
+  rows: [
+    {
+      accession: '1053852',
+      ae: 'K1234',
+      awardNumber: '2025-111',
+      nifaProject: 'CA-A-111-H',
+      orgr: 'ATM',
+      pi: 'Larkspur, S.',
+      sfn: '201',
+      status: 'Clean',
+    },
+    {
+      accession: '1055356',
+      ae: 'K2222',
+      awardNumber: '2025-222',
+      nifaProject: 'CA-B-222-CG',
+      orgr: 'ANS',
+      pi: 'Okonkwo, Y.',
+      sfn: '204',
+      status: '204 outside college',
+    },
+    {
+      accession: '1078258',
+      ae: null,
+      awardNumber: '2025-333',
+      nifaProject: 'CA-C-333-CG',
+      orgr: 'VEN',
+      pi: 'Naidoo, T.',
+      sfn: '204',
+      status: 'No PGM match',
+    },
+  ],
+  summary: {
+    activeNifa: 25,
+    allNifa: 42,
+    alnCodes: 7,
+    issuesToResolve: 2,
+    pgmRecords: 18,
+    sfnDistribution: [
+      { count: 1, sfn: '201' },
+      { count: 2, sfn: '204' },
+    ],
+  },
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('AD419 workflow routes', () => {
   it('redirects the authenticated homepage to the first workflow stage', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00-07:00'));
+    let requestedFy: string | null = null;
+
     server.use(
       http.get('/api/user/me', () => {
         return HttpResponse.json(mockUser);
       }),
       http.get('/api/imports/recent', () => {
         return HttpResponse.json([]);
+      }),
+      http.get('/api/projectlist', ({ request }) => {
+        requestedFy = new URL(request.url).searchParams.get('fy');
+        return HttpResponse.json(projectListResponse);
       })
     );
 
@@ -34,12 +101,77 @@ describe('AD419 workflow routes', () => {
       ).toBeInTheDocument();
       expect(screen.getByLabelText('Dataset')).toBeInTheDocument();
       expect(screen.getByLabelText('Import file')).toBeInTheDocument();
+      expect(
+        await screen.findByRole('heading', { name: 'Project list · 3' })
+      ).toBeInTheDocument();
+      expect(screen.getByText('Active NIFA')).toBeInTheDocument();
+      expect(screen.getByText('Issues to resolve')).toBeInTheDocument();
+      expect(
+        screen.getByRole('tab', { name: /issues\s*2/i })
+      ).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: /clean\s*1/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /all\s*3/i })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'NIFA Project' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Accession' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Award #' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'AE' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'PI' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'ORGR' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'SFN' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+      expect(screen.getByText('204 outside CAES')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Finalize' })).toBeDisabled();
 
       await waitFor(() => {
         expect(router.state.location.pathname).toBe(
           '/workflow/project-identification'
         );
       });
+      expect(requestedFy).toBe('FY26');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('filters the project list tabs and search text', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00-07:00'));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    server.use(
+      http.get('/api/user/me', () => {
+        return HttpResponse.json(mockUser);
+      }),
+      http.get('/api/imports/recent', () => {
+        return HttpResponse.json([]);
+      }),
+      http.get('/api/projectlist', () => {
+        return HttpResponse.json(projectListResponse);
+      })
+    );
+
+    const { cleanup } = renderRoute({
+      initialPath: '/workflow/project-identification',
+    });
+
+    try {
+      expect(await screen.findByText('Okonkwo, Y.')).toBeInTheDocument();
+      expect(screen.queryByText('Larkspur, S.')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('tab', { name: /clean\s*1/i }));
+      expect(await screen.findByText('Larkspur, S.')).toBeInTheDocument();
+      expect(screen.queryByText('Okonkwo, Y.')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('tab', { name: /all\s*3/i }));
+      expect(await screen.findByText('Naidoo, T.')).toBeInTheDocument();
+      await user.type(
+        screen.getByPlaceholderText('Search project, accession, PI...'),
+        '1078258'
+      );
+
+      expect(screen.getByText('Naidoo, T.')).toBeInTheDocument();
+      expect(screen.queryByText('Okonkwo, Y.')).not.toBeInTheDocument();
+      expect(screen.queryByText('Larkspur, S.')).not.toBeInTheDocument();
     } finally {
       cleanup();
     }

--- a/database/data/StoredProcedures/GetProjectList.sql
+++ b/database/data/StoredProcedures/GetProjectList.sql
@@ -70,6 +70,8 @@ BEGIN
             ap.Title,
             a.ProjectDirector AS ActiveProjectDirector,
             ap.ProjectDirector AS AllProjectDirector,
+            a.UcpEmployeeId,
+            a.UcPathName,
             ap.Department,
             ap.ProjectStartDate,
             ap.ProjectEndDate,
@@ -95,6 +97,8 @@ BEGIN
             ac.NifaAwardNumber,
             ac.Title,
             COALESCE(NULLIF(ac.ActiveProjectDirector, ''), NULLIF(ac.AllProjectDirector, '')) AS Pi,
+            ac.UcpEmployeeId,
+            ac.UcPathName,
             ac.Department,
             ac.ProjectStartDate,
             ac.ProjectEndDate,
@@ -138,6 +142,8 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100))      AS AwardNumber,
         CAST(PgmProjectNumbers AS NVARCHAR(MAX))    AS Ae,
         CAST(Pi AS NVARCHAR(200))                   AS Pi,
+        CAST(UcpEmployeeId AS NVARCHAR(8))          AS UcpEmployeeId,
+        CAST(UcPathName AS NVARCHAR(200))           AS UcPathName,
         CAST(Department AS NVARCHAR(300))           AS Department,
         CAST(NifaSfn AS NVARCHAR(10))               AS Sfn,
         CAST('Not in All Projects' AS NVARCHAR(30)) AS Status
@@ -153,6 +159,8 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
+        CAST(UcpEmployeeId AS NVARCHAR(8)),
+        CAST(UcPathName AS NVARCHAR(200)),
         CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Expired' AS NVARCHAR(30))
@@ -172,6 +180,8 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
+        CAST(UcpEmployeeId AS NVARCHAR(8)),
+        CAST(UcPathName AS NVARCHAR(200)),
         CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('No PGM match' AS NVARCHAR(30))
@@ -188,6 +198,8 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
+        CAST(UcpEmployeeId AS NVARCHAR(8)),
+        CAST(UcPathName AS NVARCHAR(200)),
         CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('SFN mismatch' AS NVARCHAR(30))
@@ -203,6 +215,8 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
+        CAST(UcpEmployeeId AS NVARCHAR(8)),
+        CAST(UcPathName AS NVARCHAR(200)),
         CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Clean' AS NVARCHAR(30))
@@ -224,6 +238,8 @@ BEGIN
         CAST(pc.SponsorAwardNumber AS NVARCHAR(100)) AS AwardNumber,
         STRING_AGG(CAST(pc.ProjectNumber AS NVARCHAR(MAX)), ', ') AS Ae,
         CAST(NULL AS NVARCHAR(200))                  AS Pi,
+        CAST(NULL AS NVARCHAR(8))                    AS UcpEmployeeId,
+        CAST(NULL AS NVARCHAR(200))                  AS UcPathName,
         CAST(NULL AS NVARCHAR(300))                  AS Department,
         CAST('204' AS NVARCHAR(10))                  AS Sfn,
         CAST('204 outside college' AS NVARCHAR(30))  AS Status

--- a/database/data/StoredProcedures/GetProjectList.sql
+++ b/database/data/StoredProcedures/GetProjectList.sql
@@ -70,7 +70,7 @@ BEGIN
             ap.Title,
             a.ProjectDirector AS ActiveProjectDirector,
             ap.ProjectDirector AS AllProjectDirector,
-            ap.Department AS Orgr,
+            ap.Department,
             ap.ProjectStartDate,
             ap.ProjectEndDate,
             CASE WHEN ap.ProjectNumber IS NULL THEN 0 ELSE 1 END AS InAllProjects,
@@ -95,7 +95,7 @@ BEGIN
             ac.NifaAwardNumber,
             ac.Title,
             COALESCE(NULLIF(ac.ActiveProjectDirector, ''), NULLIF(ac.AllProjectDirector, '')) AS Pi,
-            ac.Orgr,
+            ac.Department,
             ac.ProjectStartDate,
             ac.ProjectEndDate,
             ac.InAllProjects,
@@ -138,7 +138,7 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100))      AS AwardNumber,
         CAST(PgmProjectNumbers AS NVARCHAR(MAX))    AS Ae,
         CAST(Pi AS NVARCHAR(200))                   AS Pi,
-        CAST(Orgr AS NVARCHAR(300))                 AS Orgr,
+        CAST(Department AS NVARCHAR(300))           AS Department,
         CAST(NifaSfn AS NVARCHAR(10))               AS Sfn,
         CAST('Not in All Projects' AS NVARCHAR(30)) AS Status
     FROM ActiveWithPgm
@@ -153,7 +153,7 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
-        CAST(Orgr AS NVARCHAR(300)),
+        CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Expired' AS NVARCHAR(30))
     FROM ActiveWithPgm
@@ -172,7 +172,7 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
-        CAST(Orgr AS NVARCHAR(300)),
+        CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('No PGM match' AS NVARCHAR(30))
     FROM ActiveWithPgm
@@ -188,7 +188,7 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
-        CAST(Orgr AS NVARCHAR(300)),
+        CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('SFN mismatch' AS NVARCHAR(30))
     FROM ActiveWithPgm
@@ -203,7 +203,7 @@ BEGIN
         CAST(NifaAwardNumber AS NVARCHAR(100)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
         CAST(Pi AS NVARCHAR(200)),
-        CAST(Orgr AS NVARCHAR(300)),
+        CAST(Department AS NVARCHAR(300)),
         CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Clean' AS NVARCHAR(30))
     FROM ActiveWithPgm
@@ -224,7 +224,7 @@ BEGIN
         CAST(pc.SponsorAwardNumber AS NVARCHAR(100)) AS AwardNumber,
         STRING_AGG(CAST(pc.ProjectNumber AS NVARCHAR(MAX)), ', ') AS Ae,
         CAST(NULL AS NVARCHAR(200))                  AS Pi,
-        CAST(NULL AS NVARCHAR(300))                  AS Orgr,
+        CAST(NULL AS NVARCHAR(300))                  AS Department,
         CAST('204' AS NVARCHAR(10))                  AS Sfn,
         CAST('204 outside college' AS NVARCHAR(30))  AS Status
     FROM PgmClassified pc

--- a/database/data/StoredProcedures/GetProjectList.sql
+++ b/database/data/StoredProcedures/GetProjectList.sql
@@ -34,6 +34,8 @@ BEGIN
             pgm.ProjectId,
             pgm.ProjectNumber,
             pgm.SponsorAwardNumber,
+            pgm.AwardStartDate,
+            pgm.AwardEndDate,
             REPLACE(pgm.SponsorAwardNumber, '-', '') AS AwardKey,
             CASE
                 WHEN aln.ProgramNumber IS NULL                                              THEN NULL
@@ -80,7 +82,9 @@ BEGIN
                 ELSE 'UNKNOWN'  -- unrecognized suffix: fail closed below, never silently Clean
             END AS NifaSfn
         FROM [data].[ActiveProjects] a
-        LEFT JOIN [data].[AllProjects] ap ON ap.ProjectNumber = a.ProjectNumber
+        LEFT JOIN [data].[AllProjects] ap
+            ON NULLIF(LTRIM(RTRIM(ap.ProjectNumber)), '') = NULLIF(LTRIM(RTRIM(a.ProjectNumber)), '')
+           AND NULLIF(LTRIM(RTRIM(ap.AccessionNumber)), '') = NULLIF(LTRIM(RTRIM(a.AccessionNumber)), '')
         WHERE ISNULL(a.ExcludeFromUi, 0) = 0
     ),
     ActiveWithPgm AS
@@ -225,11 +229,15 @@ BEGIN
         CAST('204 outside college' AS NVARCHAR(30))  AS Status
     FROM PgmClassified pc
     WHERE pc.PgmSfnBucket = '204'
+      AND (pc.AwardEndDate IS NULL OR pc.AwardEndDate >= @cycleStart)
+      AND (pc.AwardStartDate IS NULL OR pc.AwardStartDate <= @cycleEnd)
       AND NOT EXISTS
       (
           SELECT 1
           FROM [data].[ActiveProjects] a
-          JOIN [data].[AllProjects] ap ON ap.ProjectNumber = a.ProjectNumber
+          JOIN [data].[AllProjects] ap
+            ON NULLIF(LTRIM(RTRIM(ap.ProjectNumber)), '') = NULLIF(LTRIM(RTRIM(a.ProjectNumber)), '')
+           AND NULLIF(LTRIM(RTRIM(ap.AccessionNumber)), '') = NULLIF(LTRIM(RTRIM(a.AccessionNumber)), '')
           WHERE ISNULL(a.ExcludeFromUi, 0) = 0
             AND ap.AwardNumber IS NOT NULL
             AND REPLACE(ap.AwardNumber, '-', '') = pc.AwardKey

--- a/database/data/StoredProcedures/GetProjectList.sql
+++ b/database/data/StoredProcedures/GetProjectList.sql
@@ -66,6 +66,9 @@ BEGIN
             a.ProjectNumber AS NifaProjectNumber,
             ap.AwardNumber  AS NifaAwardNumber,
             ap.Title,
+            a.ProjectDirector AS ActiveProjectDirector,
+            ap.ProjectDirector AS AllProjectDirector,
+            ap.Department AS Orgr,
             ap.ProjectStartDate,
             ap.ProjectEndDate,
             CASE WHEN ap.ProjectNumber IS NULL THEN 0 ELSE 1 END AS InAllProjects,
@@ -87,6 +90,8 @@ BEGIN
             ac.NifaProjectNumber,
             ac.NifaAwardNumber,
             ac.Title,
+            COALESCE(NULLIF(ac.ActiveProjectDirector, ''), NULLIF(ac.AllProjectDirector, '')) AS Pi,
+            ac.Orgr,
             ac.ProjectStartDate,
             ac.ProjectEndDate,
             ac.InAllProjects,
@@ -124,12 +129,14 @@ BEGIN
 
     -- Not in All Projects
     SELECT
-        CAST(AccessionNumber AS NVARCHAR(50))      AS AccessionNumber,
-        CAST(NifaProjectNumber AS NVARCHAR(20))    AS NifaProjectNumber,
-        CAST(NifaAwardNumber AS NVARCHAR(100))     AS NifaAwardNumber,
-        CAST(Title AS NVARCHAR(MAX))               AS Title,
-        CAST(PgmProjectNumbers AS NVARCHAR(MAX))   AS PgmProjectNumbers,
-        CAST('Not in All Projects' AS NVARCHAR(30)) AS status
+        CAST(NifaProjectNumber AS NVARCHAR(20))     AS NifaProject,
+        CAST(AccessionNumber AS NVARCHAR(50))       AS Accession,
+        CAST(NifaAwardNumber AS NVARCHAR(100))      AS AwardNumber,
+        CAST(PgmProjectNumbers AS NVARCHAR(MAX))    AS Ae,
+        CAST(Pi AS NVARCHAR(200))                   AS Pi,
+        CAST(Orgr AS NVARCHAR(300))                 AS Orgr,
+        CAST(NifaSfn AS NVARCHAR(10))               AS Sfn,
+        CAST('Not in All Projects' AS NVARCHAR(30)) AS Status
     FROM ActiveWithPgm
     WHERE InAllProjects = 0
 
@@ -137,11 +144,13 @@ BEGIN
 
     -- Expired (project dates fall outside the cycle window)
     SELECT
-        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaProjectNumber AS NVARCHAR(20)),
+        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaAwardNumber AS NVARCHAR(100)),
-        CAST(Title AS NVARCHAR(MAX)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
+        CAST(Pi AS NVARCHAR(200)),
+        CAST(Orgr AS NVARCHAR(300)),
+        CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Expired' AS NVARCHAR(30))
     FROM ActiveWithPgm
     WHERE InAllProjects = 1
@@ -154,11 +163,13 @@ BEGIN
 
     -- No PGM match
     SELECT
-        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaProjectNumber AS NVARCHAR(20)),
+        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaAwardNumber AS NVARCHAR(100)),
-        CAST(Title AS NVARCHAR(MAX)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
+        CAST(Pi AS NVARCHAR(200)),
+        CAST(Orgr AS NVARCHAR(300)),
+        CAST(NifaSfn AS NVARCHAR(10)),
         CAST('No PGM match' AS NVARCHAR(30))
     FROM ActiveWithPgm
     WHERE InAllProjects = 1
@@ -168,11 +179,13 @@ BEGIN
 
     -- SFN mismatch
     SELECT
-        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaProjectNumber AS NVARCHAR(20)),
+        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaAwardNumber AS NVARCHAR(100)),
-        CAST(Title AS NVARCHAR(MAX)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
+        CAST(Pi AS NVARCHAR(200)),
+        CAST(Orgr AS NVARCHAR(300)),
+        CAST(NifaSfn AS NVARCHAR(10)),
         CAST('SFN mismatch' AS NVARCHAR(30))
     FROM ActiveWithPgm
     WHERE HasSfnMismatch = 1
@@ -181,11 +194,13 @@ BEGIN
 
     -- Clean (fails nothing)
     SELECT
-        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaProjectNumber AS NVARCHAR(20)),
+        CAST(AccessionNumber AS NVARCHAR(50)),
         CAST(NifaAwardNumber AS NVARCHAR(100)),
-        CAST(Title AS NVARCHAR(MAX)),
         CAST(PgmProjectNumbers AS NVARCHAR(MAX)),
+        CAST(Pi AS NVARCHAR(200)),
+        CAST(Orgr AS NVARCHAR(300)),
+        CAST(NifaSfn AS NVARCHAR(10)),
         CAST('Clean' AS NVARCHAR(30))
     FROM ActiveWithPgm
     WHERE InAllProjects = 1
@@ -200,12 +215,14 @@ BEGIN
 
     -- 204 outside college: a PGM 204 award not tied to any active project
     SELECT
-        CAST(NULL AS NVARCHAR(50))                     AS AccessionNumber,
-        CAST(NULL AS NVARCHAR(20))                     AS NifaProjectNumber,
-        CAST(pc.SponsorAwardNumber AS NVARCHAR(100))   AS NifaAwardNumber,
-        CAST(NULL AS NVARCHAR(MAX))                    AS Title,
-        STRING_AGG(CAST(pc.ProjectNumber AS NVARCHAR(MAX)), ', ') AS PgmProjectNumbers,
-        CAST('204 outside college' AS NVARCHAR(30))    AS status
+        CAST(NULL AS NVARCHAR(20))                   AS NifaProject,
+        CAST(NULL AS NVARCHAR(50))                   AS Accession,
+        CAST(pc.SponsorAwardNumber AS NVARCHAR(100)) AS AwardNumber,
+        STRING_AGG(CAST(pc.ProjectNumber AS NVARCHAR(MAX)), ', ') AS Ae,
+        CAST(NULL AS NVARCHAR(200))                  AS Pi,
+        CAST(NULL AS NVARCHAR(300))                  AS Orgr,
+        CAST('204' AS NVARCHAR(10))                  AS Sfn,
+        CAST('204 outside college' AS NVARCHAR(30))  AS Status
     FROM PgmClassified pc
     WHERE pc.PgmSfnBucket = '204'
       AND NOT EXISTS

--- a/server.core/Data/AppDbContext.cs
+++ b/server.core/Data/AppDbContext.cs
@@ -10,6 +10,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<ImportLog> ImportLogs => Set<ImportLog>();
     public DbSet<User> Users => Set<User>();
+    public DbSet<WorkflowRun> WorkflowRuns => Set<WorkflowRun>();
+    public DbSet<WorkflowChecklistItemState> WorkflowChecklistItemStates => Set<WorkflowChecklistItemState>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -18,5 +20,13 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.HasDefaultSchema(AppSchema);
         modelBuilder.Entity<ImportLog>().ToTable("ImportLog", AppSchema);
         modelBuilder.Entity<User>().ToTable("Users", AppSchema);
+        modelBuilder.Entity<WorkflowRun>().ToTable("WorkflowRun", AppSchema);
+        modelBuilder.Entity<WorkflowChecklistItemState>().ToTable("WorkflowChecklistItemState", AppSchema);
+
+        modelBuilder.Entity<WorkflowRun>()
+            .HasMany(run => run.ChecklistItemStates)
+            .WithOne(state => state.WorkflowRun)
+            .HasForeignKey(state => state.WorkflowRunId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/server.core/Data/AppDbContext.cs
+++ b/server.core/Data/AppDbContext.cs
@@ -24,9 +24,20 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<WorkflowChecklistItemState>().ToTable("WorkflowChecklistItemState", AppSchema);
 
         modelBuilder.Entity<WorkflowRun>()
+            .HasIndex(run => run.IsCurrent)
+            .IsUnique()
+            .HasFilter("[IsCurrent] = 1");
+
+        modelBuilder.Entity<WorkflowRun>()
             .HasMany(run => run.ChecklistItemStates)
             .WithOne(state => state.WorkflowRun)
             .HasForeignKey(state => state.WorkflowRunId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<WorkflowChecklistItemState>()
+            .HasOne(state => state.SourceImportLog)
+            .WithMany()
+            .HasForeignKey(state => state.SourceImportLogId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/server.core/Domain/WorkflowChecklistItemState.cs
+++ b/server.core/Domain/WorkflowChecklistItemState.cs
@@ -31,6 +31,8 @@ public class WorkflowChecklistItemState
 
     public int? SourceImportLogId { get; set; }
 
+    public ImportLog? SourceImportLog { get; set; }
+
     [MaxLength(160)]
     public string? SourceKey { get; set; }
 

--- a/server.core/Domain/WorkflowChecklistItemState.cs
+++ b/server.core/Domain/WorkflowChecklistItemState.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Server.Core.Domain;
+
+[Index(nameof(WorkflowRunId), nameof(ItemId), IsUnique = true)]
+public class WorkflowChecklistItemState
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int WorkflowRunId { get; set; }
+
+    public WorkflowRun WorkflowRun { get; set; } = null!;
+
+    [Required]
+    [MaxLength(80)]
+    public string ItemId { get; set; } = string.Empty;
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    public Guid? CompletedByEntraId { get; set; }
+
+    [MaxLength(200)]
+    public string? CompletedByName { get; set; }
+
+    [MaxLength(320)]
+    public string? CompletedByEmail { get; set; }
+
+    public int? SourceImportLogId { get; set; }
+
+    [MaxLength(160)]
+    public string? SourceKey { get; set; }
+
+    public int? SourceRows { get; set; }
+
+    public DateTimeOffset? SourceCompletedAt { get; set; }
+}

--- a/server.core/Domain/WorkflowRun.cs
+++ b/server.core/Domain/WorkflowRun.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
 
 namespace Server.Core.Domain;
 
-[Index(nameof(IsCurrent))]
 public class WorkflowRun
 {
     [Key]

--- a/server.core/Domain/WorkflowRun.cs
+++ b/server.core/Domain/WorkflowRun.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Server.Core.Domain;
+
+[Index(nameof(IsCurrent))]
+public class WorkflowRun
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(16)]
+    public string FiscalYear { get; set; } = string.Empty;
+
+    public DateOnly CycleStart { get; set; }
+
+    public DateOnly CycleEnd { get; set; }
+
+    public bool IsCurrent { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public Guid? CreatedByEntraId { get; set; }
+
+    [MaxLength(200)]
+    public string? CreatedByName { get; set; }
+
+    [MaxLength(320)]
+    public string? CreatedByEmail { get; set; }
+
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public Guid? UpdatedByEntraId { get; set; }
+
+    [MaxLength(200)]
+    public string? UpdatedByName { get; set; }
+
+    [MaxLength(320)]
+    public string? UpdatedByEmail { get; set; }
+
+    public List<WorkflowChecklistItemState> ChecklistItemStates { get; set; } = [];
+}

--- a/server.core/Import/PgmProjectsImportService.cs
+++ b/server.core/Import/PgmProjectsImportService.cs
@@ -15,6 +15,21 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
     private const string DestinationTable = "[data].[PGMProjects]";
+    private const int MaxInlineAggregateLength = 255;
+
+    private static readonly PeopleAggregateField[] PeopleAggregateFields =
+    [
+        new(
+            "principal_investigator_person_name",
+            "principal_investigator_names",
+            "PrincipalInvestigatorNames",
+            "principal investigators"),
+        new("piperson", "pi_persons", "PiPersons", "PI persons"),
+        new("award_copi_name", "award_copi_names", "AwardCopiNames", "award co-PIs"),
+        new("project_manager_name", "project_manager_names", "ProjectManagerNames", "project managers"),
+        new("grant_administrator", "grant_administrators", "GrantAdministrators", "grant administrators"),
+        new("contractadmin", "contract_admins", "ContractAdmins", "contract admins"),
+    ];
 
     // source reader column -> destination table column.
     // LoadedAt is intentionally absent: the destination column defaults to
@@ -104,8 +119,6 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
         query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildRemoteQuery() });
         query.Parameters.Add(new SqlParameter("@reportDate", SqlDbType.Date) { Value = reportDate });
 
-        await using var reader = await query.ExecuteReaderAsync(cancellationToken);
-
         await using var destination = new SqlConnection(destinationConnectionString);
         await destination.OpenAsync(cancellationToken);
         await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
@@ -127,10 +140,16 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
             bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
         }
 
-        await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
         var rowsImported = (int)bulkCopy.RowsCopied64;
 
         await transaction.CommitAsync(cancellationToken);
+
+        await LogPeopleAggregateTruncationWarningsAsync(source, destination, cancellationToken);
 
         _logger.LogInformation(
             "Imported {RowCount} PGM projects for report date {ReportDate}",
@@ -138,6 +157,132 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
             reportDate);
 
         return new PgmProjectsImportResult(rowsImported, reportDate);
+    }
+
+    private async Task LogPeopleAggregateTruncationWarningsAsync(
+        SqlConnection source,
+        SqlConnection destination,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var sourceLengths = await ReadOversizedSourceAggregateLengthsAsync(source, cancellationToken);
+            if (sourceLengths.Count == 0)
+            {
+                return;
+            }
+
+            var storedLengths = await ReadStoredAggregateLengthsAsync(destination, cancellationToken);
+            var truncatedFields = FindTruncatedAggregateFields(sourceLengths, storedLengths);
+
+            if (truncatedFields.Count == 0)
+            {
+                return;
+            }
+
+            _logger.LogWarning(
+                "PGM project people aggregates were truncated by the {MaxLength}-character import query cast: {TruncatedFields}",
+                MaxInlineAggregateLength,
+                string.Join("; ", truncatedFields));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Unable to validate PGM project aggregate truncation after import.");
+        }
+    }
+
+    private static async Task<List<PeopleAggregateLengths>> ReadOversizedSourceAggregateLengthsAsync(
+        SqlConnection source,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new SqlCommand(BuildAggregateLengthCheckCommandText(), source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        command.Parameters.Add(
+            new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildAggregateLengthCheckQuery() });
+
+        var sourceLengths = new List<PeopleAggregateLengths>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            sourceLengths.Add(ReadAggregateLengths(reader, "project_id", field => $"{field.RemoteAlias}_length"));
+        }
+
+        return sourceLengths;
+    }
+
+    private static async Task<Dictionary<long, PeopleAggregateLengths>> ReadStoredAggregateLengthsAsync(
+        SqlConnection destination,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new SqlCommand(BuildStoredAggregateLengthQuery(), destination)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+
+        var storedLengths = new Dictionary<long, PeopleAggregateLengths>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var lengths = ReadAggregateLengths(reader, "ProjectId", field => $"{field.DestinationColumn}Length");
+            storedLengths[lengths.ProjectId] = lengths;
+        }
+
+        return storedLengths;
+    }
+
+    private static List<string> FindTruncatedAggregateFields(
+        IReadOnlyList<PeopleAggregateLengths> sourceLengths,
+        IReadOnlyDictionary<long, PeopleAggregateLengths> storedLengths)
+    {
+        var truncatedFields = new List<string>();
+
+        foreach (var sourceRow in sourceLengths)
+        {
+            if (!storedLengths.TryGetValue(sourceRow.ProjectId, out var storedRow))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < PeopleAggregateFields.Length; i++)
+            {
+                var sourceLength = sourceRow.FieldLengths[i];
+                var storedLength = storedRow.FieldLengths[i];
+
+                if (sourceLength <= storedLength)
+                {
+                    continue;
+                }
+
+                truncatedFields.Add(
+                    $"project {sourceRow.ProjectId} {PeopleAggregateFields[i].DisplayName}: source length {sourceLength}, stored length {storedLength}");
+            }
+        }
+
+        return truncatedFields;
+    }
+
+    private static PeopleAggregateLengths ReadAggregateLengths(
+        IDataRecord record,
+        string projectIdColumn,
+        Func<PeopleAggregateField, string> lengthColumnName)
+    {
+        var lengths = new long[PeopleAggregateFields.Length];
+        for (var i = 0; i < PeopleAggregateFields.Length; i++)
+        {
+            lengths[i] = ReadInt64(record, lengthColumnName(PeopleAggregateFields[i]));
+        }
+
+        return new PeopleAggregateLengths(ReadInt64(record, projectIdColumn), lengths);
+    }
+
+    private static long ReadInt64(IDataRecord record, string columnName)
+    {
+        var value = record.GetValue(record.GetOrdinal(columnName));
+        return value == DBNull.Value ? 0 : Convert.ToInt64(value);
     }
 
     /// <summary>
@@ -150,6 +295,62 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
     /// </summary>
     public static string BuildSourceCommandText() =>
         $"EXEC (@remoteQuery, @reportDate) AT [{RemoteLinkedServer}];";
+
+    /// <summary>
+    /// The T-SQL run against the warehouse gateway server to check whether any source people
+    /// aggregates exceed the inline cast limit used by the import query.
+    /// </summary>
+    public static string BuildAggregateLengthCheckCommandText() =>
+        $"EXEC (@remoteQuery) AT [{RemoteLinkedServer}];";
+
+    /// <summary>
+    /// Builds the Redshift query that returns numeric aggregate length telemetry. It intentionally
+    /// does not return the LISTAGG values themselves, so the linked server can bind the results as
+    /// ordinary numeric columns instead of streamed LOBs.
+    /// </summary>
+    public static string BuildAggregateLengthCheckQuery() =>
+        $$"""
+        WITH people_lengths AS (
+            SELECT project_id,
+        {{BuildSourceAggregateLengthSelectList()}}
+            FROM ae_dwh.pgm_master_data
+            WHERE project_id IS NOT NULL
+            GROUP BY project_id
+        )
+        SELECT project_id,
+        {{BuildSourceAggregateLengthResultList()}}
+        FROM people_lengths
+        WHERE {{BuildSourceAggregateLengthWhereClause()}}
+        """;
+
+    public static string BuildStoredAggregateLengthQuery() =>
+        $"""
+        SELECT ProjectId,
+        {BuildStoredAggregateLengthSelectList()}
+        FROM {DestinationTable}
+        """;
+
+    private static string BuildSourceAggregateLengthSelectList() =>
+        string.Join(
+            ",\n",
+            PeopleAggregateFields.Select(field =>
+                $"            LENGTH(LISTAGG(DISTINCT {field.SourceColumn}, '; ')) AS {field.RemoteAlias}_length"));
+
+    private static string BuildSourceAggregateLengthResultList() =>
+        string.Join(
+            ",\n",
+            PeopleAggregateFields.Select(field => $"    COALESCE({field.RemoteAlias}_length, 0) AS {field.RemoteAlias}_length"));
+
+    private static string BuildSourceAggregateLengthWhereClause() =>
+        string.Join(
+            "\n   OR ",
+            PeopleAggregateFields.Select(field => $"{field.RemoteAlias}_length > {MaxInlineAggregateLength}"));
+
+    private static string BuildStoredAggregateLengthSelectList() =>
+        string.Join(
+            ",\n",
+            PeopleAggregateFields.Select(field =>
+                $"    COALESCE(DATALENGTH({field.DestinationColumn}) / 2, 0) AS {field.DestinationColumn}Length"));
 
     /// <summary>
     /// Builds the Redshift query run on the warehouse via the pass-through. The single <c>?</c> is
@@ -166,7 +367,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
     /// not selected here; the destination column defaults to it.
     /// </summary>
     public static string BuildRemoteQuery() =>
-        """
+        $"""
         WITH ranked AS (
             SELECT pmd.*,
                 ROW_NUMBER() OVER (
@@ -182,12 +383,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
         ),
         people AS (
             SELECT project_id,
-                CAST(LISTAGG(DISTINCT principal_investigator_person_name, '; ') AS VARCHAR(255)) AS principal_investigator_names,
-                CAST(LISTAGG(DISTINCT piperson, '; ') AS VARCHAR(255)) AS pi_persons,
-                CAST(LISTAGG(DISTINCT award_copi_name, '; ') AS VARCHAR(255)) AS award_copi_names,
-                CAST(LISTAGG(DISTINCT project_manager_name, '; ') AS VARCHAR(255)) AS project_manager_names,
-                CAST(LISTAGG(DISTINCT grant_administrator, '; ') AS VARCHAR(255)) AS grant_administrators,
-                CAST(LISTAGG(DISTINCT contractadmin, '; ') AS VARCHAR(255)) AS contract_admins
+        {BuildPeopleAggregateSelectList()}
             FROM ae_dwh.pgm_master_data
             WHERE project_id IS NOT NULL
             GROUP BY project_id
@@ -209,4 +405,18 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
         JOIN people p USING (project_id)
         WHERE r.rn = 1
         """;
+
+    private static string BuildPeopleAggregateSelectList() =>
+        string.Join(
+            ",\n",
+            PeopleAggregateFields.Select(field =>
+                $"            CAST(LISTAGG(DISTINCT {field.SourceColumn}, '; ') AS VARCHAR({MaxInlineAggregateLength})) AS {field.RemoteAlias}"));
+
+    private sealed record PeopleAggregateField(
+        string SourceColumn,
+        string RemoteAlias,
+        string DestinationColumn,
+        string DisplayName);
+
+    private sealed record PeopleAggregateLengths(long ProjectId, long[] FieldLengths);
 }

--- a/server.core/Import/PgmProjectsImportService.cs
+++ b/server.core/Import/PgmProjectsImportService.cs
@@ -157,8 +157,11 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
     /// single-valued attributes come from the budget period containing the report date (falling
     /// back to the most recent period); people columns aggregate distinct names across all of the
     /// project's rows. Rows with a null project_id are excluded (they otherwise collapse into one
-    /// junk bucket). LISTAGG results are cast to a bounded VARCHAR so MSDASQL binds them inline
-    /// rather than as LOBs, which EXEC ... AT cannot stream. Redshift also disallows differing
+    /// junk bucket). LISTAGG results are cast to a narrow VARCHAR(255) so MSDASQL binds them inline
+    /// rather than as LOBs, which EXEC ... AT cannot stream: the Redshift ODBC driver reports any
+    /// wider VARCHAR as SQL_LONGVARCHAR (streamed) even when the values are short, which fails with
+    /// error 7341 "cannot get the current row value". Real values are tiny (observed max ~43 chars,
+    /// a project has at most a handful of distinct people), so 255 has ample headroom. Redshift also disallows differing
     /// LISTAGG WITHIN GROUP orderings and a trailing semicolon inside the pass-through. LoadedAt is
     /// not selected here; the destination column defaults to it.
     /// </summary>
@@ -179,12 +182,12 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
         ),
         people AS (
             SELECT project_id,
-                CAST(LISTAGG(DISTINCT principal_investigator_person_name, '; ') AS VARCHAR(8000)) AS principal_investigator_names,
-                CAST(LISTAGG(DISTINCT piperson, '; ') AS VARCHAR(8000)) AS pi_persons,
-                CAST(LISTAGG(DISTINCT award_copi_name, '; ') AS VARCHAR(8000)) AS award_copi_names,
-                CAST(LISTAGG(DISTINCT project_manager_name, '; ') AS VARCHAR(8000)) AS project_manager_names,
-                CAST(LISTAGG(DISTINCT grant_administrator, '; ') AS VARCHAR(8000)) AS grant_administrators,
-                CAST(LISTAGG(DISTINCT contractadmin, '; ') AS VARCHAR(8000)) AS contract_admins
+                CAST(LISTAGG(DISTINCT principal_investigator_person_name, '; ') AS VARCHAR(255)) AS principal_investigator_names,
+                CAST(LISTAGG(DISTINCT piperson, '; ') AS VARCHAR(255)) AS pi_persons,
+                CAST(LISTAGG(DISTINCT award_copi_name, '; ') AS VARCHAR(255)) AS award_copi_names,
+                CAST(LISTAGG(DISTINCT project_manager_name, '; ') AS VARCHAR(255)) AS project_manager_names,
+                CAST(LISTAGG(DISTINCT grant_administrator, '; ') AS VARCHAR(255)) AS grant_administrators,
+                CAST(LISTAGG(DISTINCT contractadmin, '; ') AS VARCHAR(255)) AS contract_admins
             FROM ae_dwh.pgm_master_data
             WHERE project_id IS NOT NULL
             GROUP BY project_id

--- a/server.core/Import/PgmProjectsImportService.cs
+++ b/server.core/Import/PgmProjectsImportService.cs
@@ -16,6 +16,8 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
     private const string DestinationTable = "[data].[PGMProjects]";
     private const int MaxInlineAggregateLength = 255;
+    internal const string PeopleAggregateTruncationWarningMessage =
+        "PGM project people aggregates were truncated by the {MaxLength}-byte import query cast: {TruncatedFields}";
 
     private static readonly PeopleAggregateField[] PeopleAggregateFields =
     [
@@ -181,7 +183,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
             }
 
             _logger.LogWarning(
-                "PGM project people aggregates were truncated by the {MaxLength}-character import query cast: {TruncatedFields}",
+                PeopleAggregateTruncationWarningMessage,
                 MaxInlineAggregateLength,
                 string.Join("; ", truncatedFields));
         }
@@ -334,7 +336,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
         string.Join(
             ",\n",
             PeopleAggregateFields.Select(field =>
-                $"            LENGTH(LISTAGG(DISTINCT {field.SourceColumn}, '; ')) AS {field.RemoteAlias}_length"));
+                $"            OCTET_LENGTH(LISTAGG(DISTINCT {field.SourceColumn}, '; ')) AS {field.RemoteAlias}_length"));
 
     private static string BuildSourceAggregateLengthResultList() =>
         string.Join(

--- a/server.core/Migrations/20260710192848_ProjectIdentificationWorkflowState.Designer.cs
+++ b/server.core/Migrations/20260710192848_ProjectIdentificationWorkflowState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Server.Core.Data;
 
@@ -11,9 +12,11 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710192848_ProjectIdentificationWorkflowState")]
+    partial class ProjectIdentificationWorkflowState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server.core/Migrations/20260710192848_ProjectIdentificationWorkflowState.cs
+++ b/server.core/Migrations/20260710192848_ProjectIdentificationWorkflowState.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProjectIdentificationWorkflowState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkflowRun",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FiscalYear = table.Column<string>(type: "nvarchar(16)", maxLength: 16, nullable: false),
+                    CycleStart = table.Column<DateOnly>(type: "date", nullable: false),
+                    CycleEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsCurrent = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedByEntraId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    CreatedByName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    CreatedByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedByEntraId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedByName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    UpdatedByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkflowRun", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkflowChecklistItemState",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    WorkflowRunId = table.Column<int>(type: "int", nullable: false),
+                    ItemId = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CompletedByEntraId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    CompletedByName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    CompletedByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true),
+                    SourceImportLogId = table.Column<int>(type: "int", nullable: true),
+                    SourceKey = table.Column<string>(type: "nvarchar(160)", maxLength: 160, nullable: true),
+                    SourceRows = table.Column<int>(type: "int", nullable: true),
+                    SourceCompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkflowChecklistItemState", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkflowChecklistItemState_WorkflowRun_WorkflowRunId",
+                        column: x => x.WorkflowRunId,
+                        principalSchema: "app",
+                        principalTable: "WorkflowRun",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowChecklistItemState_WorkflowRunId_ItemId",
+                schema: "app",
+                table: "WorkflowChecklistItemState",
+                columns: new[] { "WorkflowRunId", "ItemId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowRun_IsCurrent",
+                schema: "app",
+                table: "WorkflowRun",
+                column: "IsCurrent");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkflowChecklistItemState",
+                schema: "app");
+
+            migrationBuilder.DropTable(
+                name: "WorkflowRun",
+                schema: "app");
+        }
+    }
+}

--- a/server.core/Migrations/20260710214615_ProjectIdentificationWorkflowState.Designer.cs
+++ b/server.core/Migrations/20260710214615_ProjectIdentificationWorkflowState.Designer.cs
@@ -12,7 +12,7 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20260710192848_ProjectIdentificationWorkflowState")]
+    [Migration("20260710214615_ProjectIdentificationWorkflowState")]
     partial class ProjectIdentificationWorkflowState
     {
         /// <inheritdoc />
@@ -157,6 +157,8 @@ namespace server.core.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SourceImportLogId");
+
                     b.HasIndex("WorkflowRunId", "ItemId")
                         .IsUnique();
 
@@ -215,18 +217,27 @@ namespace server.core.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("IsCurrent");
+                    b.HasIndex("IsCurrent")
+                        .IsUnique()
+                        .HasFilter("[IsCurrent] = 1");
 
                     b.ToTable("WorkflowRun", "app");
                 });
 
             modelBuilder.Entity("Server.Core.Domain.WorkflowChecklistItemState", b =>
                 {
+                    b.HasOne("Server.Core.Domain.ImportLog", "SourceImportLog")
+                        .WithMany()
+                        .HasForeignKey("SourceImportLogId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
                     b.HasOne("Server.Core.Domain.WorkflowRun", "WorkflowRun")
                         .WithMany("ChecklistItemStates")
                         .HasForeignKey("WorkflowRunId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.Navigation("SourceImportLog");
 
                     b.Navigation("WorkflowRun");
                 });

--- a/server.core/Migrations/20260710214615_ProjectIdentificationWorkflowState.cs
+++ b/server.core/Migrations/20260710214615_ProjectIdentificationWorkflowState.cs
@@ -58,6 +58,13 @@ namespace server.core.Migrations
                 {
                     table.PrimaryKey("PK_WorkflowChecklistItemState", x => x.Id);
                     table.ForeignKey(
+                        name: "FK_WorkflowChecklistItemState_ImportLog_SourceImportLogId",
+                        column: x => x.SourceImportLogId,
+                        principalSchema: "app",
+                        principalTable: "ImportLog",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
                         name: "FK_WorkflowChecklistItemState_WorkflowRun_WorkflowRunId",
                         column: x => x.WorkflowRunId,
                         principalSchema: "app",
@@ -65,6 +72,12 @@ namespace server.core.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowChecklistItemState_SourceImportLogId",
+                schema: "app",
+                table: "WorkflowChecklistItemState",
+                column: "SourceImportLogId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowChecklistItemState_WorkflowRunId_ItemId",
@@ -77,7 +90,9 @@ namespace server.core.Migrations
                 name: "IX_WorkflowRun_IsCurrent",
                 schema: "app",
                 table: "WorkflowRun",
-                column: "IsCurrent");
+                column: "IsCurrent",
+                unique: true,
+                filter: "[IsCurrent] = 1");
         }
 
         /// <inheritdoc />

--- a/server.core/Migrations/AppDbContextModelSnapshot.cs
+++ b/server.core/Migrations/AppDbContextModelSnapshot.cs
@@ -154,6 +154,8 @@ namespace server.core.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SourceImportLogId");
+
                     b.HasIndex("WorkflowRunId", "ItemId")
                         .IsUnique();
 
@@ -212,18 +214,27 @@ namespace server.core.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("IsCurrent");
+                    b.HasIndex("IsCurrent")
+                        .IsUnique()
+                        .HasFilter("[IsCurrent] = 1");
 
                     b.ToTable("WorkflowRun", "app");
                 });
 
             modelBuilder.Entity("Server.Core.Domain.WorkflowChecklistItemState", b =>
                 {
+                    b.HasOne("Server.Core.Domain.ImportLog", "SourceImportLog")
+                        .WithMany()
+                        .HasForeignKey("SourceImportLogId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
                     b.HasOne("Server.Core.Domain.WorkflowRun", "WorkflowRun")
                         .WithMany("ChecklistItemStates")
                         .HasForeignKey("WorkflowRunId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.Navigation("SourceImportLog");
 
                     b.Navigation("WorkflowRun");
                 });

--- a/server.core/updateDatabase.sh
+++ b/server.core/updateDatabase.sh
@@ -8,10 +8,10 @@ ROOT_DIR="$(dirname "$0")/.."
 
 if [ -z "$1" ]; then
   echo "Updating database to latest migration..."
-  dotnet ef database update -p "$ROOT_DIR/server.core" -s "$ROOT_DIR/server"
+  dotnet ef database update --context AppDbContext -p "$ROOT_DIR/server.core" -s "$ROOT_DIR/server"
 else
   echo "Updating database to migration '$1'..."
-  dotnet ef database update "$1" -p "$ROOT_DIR/server.core" -s "$ROOT_DIR/server"
+  dotnet ef database update "$1" --context AppDbContext -p "$ROOT_DIR/server.core" -s "$ROOT_DIR/server"
 fi
 
 echo "Database updated successfully."

--- a/server/Controllers/PgmProjectsController.cs
+++ b/server/Controllers/PgmProjectsController.cs
@@ -8,13 +8,16 @@ public class PgmProjectsController : ApiControllerBase
 {
     private readonly IPgmProjectsImportService _importService;
     private readonly IProjectIdentificationService _projectIdentificationService;
+    private readonly ILogger<PgmProjectsController> _logger;
 
     public PgmProjectsController(
         IPgmProjectsImportService importService,
-        IProjectIdentificationService projectIdentificationService)
+        IProjectIdentificationService projectIdentificationService,
+        ILogger<PgmProjectsController> logger)
     {
         _importService = importService;
         _projectIdentificationService = projectIdentificationService;
+        _logger = logger;
     }
 
     // POST api/pgmprojects/import?reportDate=2026-06-30
@@ -30,7 +33,22 @@ public class PgmProjectsController : ApiControllerBase
         }
 
         var result = await _importService.ImportAsync(date, cancellationToken);
-        await _projectIdentificationService.RecordPgmImportAsync(result, User, cancellationToken);
+        try
+        {
+            await _projectIdentificationService.RecordPgmImportAsync(result, User, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "PGM projects import succeeded for report date {ReportDate}, but workflow recording failed.",
+                date);
+        }
+
         return Ok(result);
     }
 }

--- a/server/Controllers/PgmProjectsController.cs
+++ b/server/Controllers/PgmProjectsController.cs
@@ -1,15 +1,20 @@
 using Microsoft.AspNetCore.Mvc;
 using Server.Core.Import;
+using Server.ProjectIdentification;
 
 namespace Server.Controllers;
 
 public class PgmProjectsController : ApiControllerBase
 {
     private readonly IPgmProjectsImportService _importService;
+    private readonly IProjectIdentificationService _projectIdentificationService;
 
-    public PgmProjectsController(IPgmProjectsImportService importService)
+    public PgmProjectsController(
+        IPgmProjectsImportService importService,
+        IProjectIdentificationService projectIdentificationService)
     {
         _importService = importService;
+        _projectIdentificationService = projectIdentificationService;
     }
 
     // POST api/pgmprojects/import?reportDate=2026-06-30
@@ -25,6 +30,7 @@ public class PgmProjectsController : ApiControllerBase
         }
 
         var result = await _importService.ImportAsync(date, cancellationToken);
+        await _projectIdentificationService.RecordPgmImportAsync(result, User, cancellationToken);
         return Ok(result);
     }
 }

--- a/server/Controllers/ProjectIdentificationController.cs
+++ b/server/Controllers/ProjectIdentificationController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using Server.Models.ProjectIdentification;
+using Server.ProjectIdentification;
+
+namespace Server.Controllers;
+
+public sealed class ProjectIdentificationController(
+    IProjectIdentificationService projectIdentificationService) : ApiControllerBase
+{
+    [HttpGet("setup")]
+    public async Task<ActionResult<ProjectIdentificationSetupResponse>> Setup(
+        CancellationToken cancellationToken)
+    {
+        var response = await projectIdentificationService.GetSetupAsync(User, cancellationToken);
+        return Ok(response);
+    }
+
+    [HttpPut("fiscal-period")]
+    public async Task<ActionResult<ProjectIdentificationSetupResponse>> ConfirmFiscalPeriod(
+        FiscalPeriodRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await projectIdentificationService.ConfirmFiscalPeriodAsync(
+            request.FiscalYear,
+            User,
+            cancellationToken);
+
+        if (response is null)
+        {
+            return BadRequest("A fiscal year value like FY26 is required.");
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPut("checklist/{itemId}")]
+    public async Task<ActionResult<ProjectIdentificationSetupResponse>> SetChecklistItemCompletion(
+        [FromRoute] string itemId,
+        ChecklistCompletionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await projectIdentificationService.SetChecklistItemCompletionAsync(
+            itemId,
+            request.Completed,
+            User,
+            cancellationToken);
+
+        if (response is null)
+        {
+            return BadRequest("The checklist item cannot be updated in its current state.");
+        }
+
+        return Ok(response);
+    }
+}

--- a/server/Controllers/ProjectListController.cs
+++ b/server/Controllers/ProjectListController.cs
@@ -14,7 +14,7 @@ public sealed class ProjectListController(IProjectListService projectListService
             return BadRequest("A fiscal year query value like FY26 is required.");
         }
 
-        var response = await projectListService.GetAsync(cycle!, cancellationToken);
+        var response = await projectListService.GetAsync(cycle, cancellationToken);
         return Ok(response);
     }
 }

--- a/server/Controllers/ProjectListController.cs
+++ b/server/Controllers/ProjectListController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using Server.Models;
+using Server.ProjectList;
+
+namespace Server.Controllers;
+
+public sealed class ProjectListController(IProjectListService projectListService) : ApiControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] string? fy, CancellationToken cancellationToken)
+    {
+        if (!FiscalYearCycle.TryParse(fy, out var cycle))
+        {
+            return BadRequest("A fiscal year query value like FY26 is required.");
+        }
+
+        var response = await projectListService.GetAsync(cycle!, cancellationToken);
+        return Ok(response);
+    }
+}

--- a/server/Models/FiscalYearCycle.cs
+++ b/server/Models/FiscalYearCycle.cs
@@ -17,14 +17,22 @@ public sealed record FiscalYearCycle(
         }
 
         var normalized = fiscalYear.Trim().ToUpperInvariant();
-        if (!normalized.StartsWith("FY", StringComparison.Ordinal) ||
-            normalized.Length < 4 ||
-            !int.TryParse(normalized[2..], NumberStyles.None, CultureInfo.InvariantCulture, out var shortYear))
+        var yearText = normalized.StartsWith("FY", StringComparison.Ordinal)
+            ? normalized[2..]
+            : string.Empty;
+
+        if (yearText.Length is not (2 or 4) ||
+            !int.TryParse(yearText, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedYear))
         {
             return false;
         }
 
-        var endYear = shortYear < 100 ? 2000 + shortYear : shortYear;
+        var endYear = yearText.Length == 2 ? 2000 + parsedYear : parsedYear;
+        if (endYear is < 2 or > 9999)
+        {
+            return false;
+        }
+
         var startYear = endYear - 1;
         cycle = new FiscalYearCycle(
             $"FY{endYear % 100:00}",

--- a/server/Models/FiscalYearCycle.cs
+++ b/server/Models/FiscalYearCycle.cs
@@ -7,9 +7,9 @@ public sealed record FiscalYearCycle(
     DateOnly CycleStart,
     DateOnly CycleEnd)
 {
-    public static bool TryParse(string? fiscalYear, out FiscalYearCycle? cycle)
+    public static bool TryParse(string? fiscalYear, out FiscalYearCycle cycle)
     {
-        cycle = null;
+        cycle = default!;
 
         if (string.IsNullOrWhiteSpace(fiscalYear))
         {

--- a/server/Models/FiscalYearCycle.cs
+++ b/server/Models/FiscalYearCycle.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+
+namespace Server.Models;
+
+public sealed record FiscalYearCycle(
+    string FiscalYear,
+    DateOnly CycleStart,
+    DateOnly CycleEnd)
+{
+    public static bool TryParse(string? fiscalYear, out FiscalYearCycle? cycle)
+    {
+        cycle = null;
+
+        if (string.IsNullOrWhiteSpace(fiscalYear))
+        {
+            return false;
+        }
+
+        var normalized = fiscalYear.Trim().ToUpperInvariant();
+        if (!normalized.StartsWith("FY", StringComparison.Ordinal) ||
+            normalized.Length < 4 ||
+            !int.TryParse(normalized[2..], NumberStyles.None, CultureInfo.InvariantCulture, out var shortYear))
+        {
+            return false;
+        }
+
+        var endYear = shortYear < 100 ? 2000 + shortYear : shortYear;
+        var startYear = endYear - 1;
+        cycle = new FiscalYearCycle(
+            $"FY{endYear % 100:00}",
+            new DateOnly(startYear, 10, 1),
+            new DateOnly(endYear, 9, 30));
+        return true;
+    }
+}

--- a/server/Models/FiscalYearCycle.cs
+++ b/server/Models/FiscalYearCycle.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Server.Models;
@@ -7,9 +8,9 @@ public sealed record FiscalYearCycle(
     DateOnly CycleStart,
     DateOnly CycleEnd)
 {
-    public static bool TryParse(string? fiscalYear, out FiscalYearCycle cycle)
+    public static bool TryParse(string? fiscalYear, [NotNullWhen(true)] out FiscalYearCycle? cycle)
     {
-        cycle = default!;
+        cycle = null;
 
         if (string.IsNullOrWhiteSpace(fiscalYear))
         {

--- a/server/Models/ProjectIdentification/ProjectIdentificationDtos.cs
+++ b/server/Models/ProjectIdentification/ProjectIdentificationDtos.cs
@@ -1,0 +1,43 @@
+using Server.Models.Imports;
+
+namespace Server.Models.ProjectIdentification;
+
+public sealed record ProjectIdentificationSetupResponse(
+    int WorkflowRunId,
+    string FiscalYear,
+    DateOnly CycleStart,
+    DateOnly CycleEnd,
+    IReadOnlyList<FiscalPeriodOptionDto> FiscalPeriodOptions,
+    int CompletedCount,
+    int TotalCount,
+    IReadOnlyList<ProjectChecklistItemDto> ChecklistItems);
+
+public sealed record FiscalPeriodOptionDto(
+    string FiscalYear,
+    DateOnly CycleStart,
+    DateOnly CycleEnd,
+    string Label);
+
+public sealed record ProjectChecklistItemDto(
+    string Id,
+    int Number,
+    string Label,
+    string Hint,
+    string Kind,
+    string Status,
+    bool Completed,
+    bool Ready,
+    bool Stale,
+    string? StaleReason,
+    RecentImportResponse? LatestImport,
+    ProjectChecklistSourceDto? Source);
+
+public sealed record ProjectChecklistSourceDto(
+    int? ImportLogId,
+    string? Key,
+    int? Rows,
+    DateTimeOffset? CompletedAt);
+
+public sealed record FiscalPeriodRequest(string FiscalYear);
+
+public sealed record ChecklistCompletionRequest(bool Completed);

--- a/server/Models/ProjectList/ProjectListDtos.cs
+++ b/server/Models/ProjectList/ProjectListDtos.cs
@@ -31,6 +31,6 @@ public sealed record ProjectListRowDto(
     string? AwardNumber,
     string? Ae,
     string? Pi,
-    string? Orgr,
+    string? Department,
     string? Sfn,
     string Status);

--- a/server/Models/ProjectList/ProjectListDtos.cs
+++ b/server/Models/ProjectList/ProjectListDtos.cs
@@ -1,0 +1,36 @@
+namespace Server.Models.ProjectList;
+
+public sealed record ProjectListResponse(
+    string FiscalYear,
+    DateOnly CycleStart,
+    DateOnly CycleEnd,
+    ProjectListCountsDto Counts,
+    ProjectListSummaryDto Summary,
+    IReadOnlyList<ProjectListRowDto> Rows);
+
+public sealed record ProjectListCountsDto(
+    int Issues,
+    int Clean,
+    int All);
+
+public sealed record ProjectListSummaryDto(
+    int ActiveNifa,
+    int AllNifa,
+    int PgmRecords,
+    int AlnCodes,
+    int IssuesToResolve,
+    IReadOnlyList<SfnDistributionDto> SfnDistribution);
+
+public sealed record SfnDistributionDto(
+    string Sfn,
+    int Count);
+
+public sealed record ProjectListRowDto(
+    string? NifaProject,
+    string? Accession,
+    string? AwardNumber,
+    string? Ae,
+    string? Pi,
+    string? Orgr,
+    string? Sfn,
+    string Status);

--- a/server/Models/ProjectList/ProjectListDtos.cs
+++ b/server/Models/ProjectList/ProjectListDtos.cs
@@ -31,6 +31,8 @@ public sealed record ProjectListRowDto(
     string? AwardNumber,
     string? Ae,
     string? Pi,
+    string? UcpEmployeeId,
+    string? UcPathName,
     string? Department,
     string? Sfn,
     string Status);

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -10,6 +10,7 @@ using Server.Import;
 using Server.Core.Import;
 using Server.Core.Notification;
 using Server.Helpers;
+using Server.ProjectList;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -55,6 +56,7 @@ builder.Services.AddScoped<IAuthorizationHandler, AuthorizedUserHandler>();
 builder.Services.AddScoped<IPgmProjectsImportService, PgmProjectsImportService>();
 builder.Services.AddSingleton<IFlatFileImportRegistry, FlatFileImportRegistry>();
 builder.Services.AddScoped<IFlatFileImportService, FlatFileImportService>();
+builder.Services.AddScoped<IProjectListService, ProjectListService>();
 // add auth policies here
 
 // add db context (check secrets first, then config, then default)

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -10,6 +10,7 @@ using Server.Import;
 using Server.Core.Import;
 using Server.Core.Notification;
 using Server.Helpers;
+using Server.ProjectIdentification;
 using Server.ProjectList;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -56,6 +57,7 @@ builder.Services.AddScoped<IAuthorizationHandler, AuthorizedUserHandler>();
 builder.Services.AddScoped<IPgmProjectsImportService, PgmProjectsImportService>();
 builder.Services.AddSingleton<IFlatFileImportRegistry, FlatFileImportRegistry>();
 builder.Services.AddScoped<IFlatFileImportService, FlatFileImportService>();
+builder.Services.AddScoped<IProjectIdentificationService, ProjectIdentificationService>();
 builder.Services.AddScoped<IProjectListService, ProjectListService>();
 // add auth policies here
 

--- a/server/ProjectIdentification/IProjectIdentificationService.cs
+++ b/server/ProjectIdentification/IProjectIdentificationService.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using Server.Core.Import;
+using Server.Models.ProjectIdentification;
+
+namespace Server.ProjectIdentification;
+
+public interface IProjectIdentificationService
+{
+    Task<ProjectIdentificationSetupResponse> GetSetupAsync(
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken);
+
+    Task<ProjectIdentificationSetupResponse?> ConfirmFiscalPeriodAsync(
+        string? fiscalYear,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken);
+
+    Task<ProjectIdentificationSetupResponse?> SetChecklistItemCompletionAsync(
+        string itemId,
+        bool completed,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken);
+
+    Task RecordPgmImportAsync(
+        PgmProjectsImportResult result,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken);
+}

--- a/server/ProjectIdentification/ProjectIdentificationService.cs
+++ b/server/ProjectIdentification/ProjectIdentificationService.cs
@@ -1,0 +1,632 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Server.Authorization;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Import;
+using Server.Models;
+using Server.Models.Imports;
+using Server.Models.ProjectIdentification;
+using Server.ProjectList;
+
+namespace Server.ProjectIdentification;
+
+public sealed class ProjectIdentificationService(
+    AppDbContext dbContext,
+    IFlatFileImportRegistry importRegistry,
+    IProjectListService projectListService) : IProjectIdentificationService
+{
+    private const string FiscalPeriodItemId = "fiscal-period";
+    private const string PgmItemId = "pgm-master-data";
+    private const string ResolveIssuesItemId = "resolve-project-issues";
+    private const string FinalizeProjectsItemId = "finalize-projects";
+
+    private static readonly ChecklistItemDefinition[] ChecklistItems =
+    [
+        new(FiscalPeriodItemId, 1, "Confirm Fiscal Period", "Set the reporting cycle", "select"),
+        new("all-projects", 2, "Upload All Projects List", "ANR - all NIFA projects across UC campuses", "upload"),
+        new("active-projects", 3, "Upload Active Project List", "ANR - CAES projects required to report", "upload"),
+        new("assistance-listing-numbers", 4, "Upload CFDA / ALN Data", "assistancelisting.usaspending.gov - updated weekly", "upload"),
+        new(PgmItemId, 5, "Import PGM Master Data", "AE Redshift - ae_dwh.pgm_master_data", "import"),
+        new(ResolveIssuesItemId, 6, "Resolve Project Issues", "Review flagged projects below", "review"),
+        new(FinalizeProjectsItemId, 7, "Finalize Projects", "Locks project data, triggers full expense pull", "action"),
+    ];
+
+    private static readonly Dictionary<string, string> DatasetByItemId = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["all-projects"] = "all-projects",
+        ["active-projects"] = "active-projects",
+        ["assistance-listing-numbers"] = "assistance-listing-numbers",
+    };
+
+    public async Task<ProjectIdentificationSetupResponse> GetSetupAsync(
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        var run = await GetOrCreateCurrentRunAsync(user, cancellationToken);
+        var latestImports = await GetLatestImportsAsync(cancellationToken);
+
+        return CreateSetupResponse(run, latestImports);
+    }
+
+    public async Task<ProjectIdentificationSetupResponse?> ConfirmFiscalPeriodAsync(
+        string? fiscalYear,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        if (!FiscalYearCycle.TryParse(fiscalYear, out var cycle))
+        {
+            return null;
+        }
+
+        var run = await GetOrCreateCurrentRunAsync(user, cancellationToken);
+        var now = DateTimeOffset.UtcNow;
+        var changed = !string.Equals(run.FiscalYear, cycle!.FiscalYear, StringComparison.OrdinalIgnoreCase);
+
+        if (changed)
+        {
+            run.FiscalYear = cycle.FiscalYear;
+            run.CycleStart = cycle.CycleStart;
+            run.CycleEnd = cycle.CycleEnd;
+            run.ChecklistItemStates.Clear();
+        }
+
+        Touch(run, user, now);
+        var fiscalState = GetOrCreateState(run, FiscalPeriodItemId);
+        CompleteState(fiscalState, user, now);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var latestImports = await GetLatestImportsAsync(cancellationToken);
+        return CreateSetupResponse(run, latestImports);
+    }
+
+    public async Task<ProjectIdentificationSetupResponse?> SetChecklistItemCompletionAsync(
+        string itemId,
+        bool completed,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        var definition = FindDefinition(itemId);
+        if (definition is null || definition.Id == FinalizeProjectsItemId)
+        {
+            return null;
+        }
+
+        var run = await GetOrCreateCurrentRunAsync(user, cancellationToken);
+        var latestImports = await GetLatestImportsAsync(cancellationToken);
+        var items = CreateChecklistItems(run, latestImports);
+        var requestedItem = items.Single(item => item.Id == definition.Id);
+
+        if (!completed)
+        {
+            ClearFrom(run, definition.Number);
+            Touch(run, user, DateTimeOffset.UtcNow);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return CreateSetupResponse(run, latestImports);
+        }
+
+        var previousComplete = items
+            .Where(item => item.Number < definition.Number)
+            .All(item => item.Completed);
+
+        if (!previousComplete || !requestedItem.Ready)
+        {
+            return null;
+        }
+
+        if (definition.Id == ResolveIssuesItemId
+            && !await ProjectIssuesResolvedAsync(run, cancellationToken))
+        {
+            return null;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var state = GetOrCreateState(run, definition.Id);
+        CompleteState(state, user, now);
+
+        if (DatasetByItemId.TryGetValue(definition.Id, out var datasetId))
+        {
+            var latestImport = latestImports.GetValueOrDefault(datasetId);
+            if (latestImport is null || !IsSucceeded(latestImport))
+            {
+                return null;
+            }
+
+            state.SourceImportLogId = latestImport.Id;
+            state.SourceRows = latestImport.RowsImported;
+            state.SourceCompletedAt = latestImport.ImportedAt;
+            state.SourceKey = null;
+        }
+        else if (definition.Id == PgmItemId)
+        {
+            if (state.SourceRows is null || state.SourceCompletedAt is null)
+            {
+                return null;
+            }
+        }
+        else
+        {
+            state.SourceImportLogId = null;
+            state.SourceRows = null;
+            state.SourceCompletedAt = null;
+            state.SourceKey = null;
+        }
+
+        Touch(run, user, now);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        latestImports = await GetLatestImportsAsync(cancellationToken);
+        return CreateSetupResponse(run, latestImports);
+    }
+
+    private async Task<bool> ProjectIssuesResolvedAsync(
+        WorkflowRun run,
+        CancellationToken cancellationToken)
+    {
+        if (!FiscalYearCycle.TryParse(run.FiscalYear, out var cycle))
+        {
+            return false;
+        }
+
+        var projectList = await projectListService.GetAsync(cycle!, cancellationToken);
+        return projectList.Summary.IssuesToResolve == 0;
+    }
+
+    public async Task RecordPgmImportAsync(
+        PgmProjectsImportResult result,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        var run = await GetOrCreateCurrentRunAsync(user, cancellationToken);
+        var now = DateTimeOffset.UtcNow;
+        var state = GetOrCreateState(run, PgmItemId);
+
+        state.CompletedAt = null;
+        state.CompletedByEntraId = null;
+        state.CompletedByName = null;
+        state.CompletedByEmail = null;
+        state.SourceImportLogId = null;
+        state.SourceKey = $"pgm:{result.ReportDate:yyyy-MM-dd}:{now:O}";
+        state.SourceRows = result.RowsImported;
+        state.SourceCompletedAt = now;
+
+        ClearAfter(run, ChecklistItems.Single(item => item.Id == PgmItemId).Number);
+        Touch(run, user, now);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<WorkflowRun> GetOrCreateCurrentRunAsync(
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        var run = await dbContext.WorkflowRuns
+            .Include(item => item.ChecklistItemStates)
+            .Where(item => item.IsCurrent)
+            .OrderByDescending(item => item.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (run is not null)
+        {
+            return run;
+        }
+
+        var cycle = CurrentFiscalYearCycle();
+        var now = DateTimeOffset.UtcNow;
+        run = new WorkflowRun
+        {
+            FiscalYear = cycle.FiscalYear,
+            CycleStart = cycle.CycleStart,
+            CycleEnd = cycle.CycleEnd,
+            CreatedAt = now,
+            IsCurrent = true,
+            UpdatedAt = now,
+        };
+
+        SetCreatedBy(run, user);
+        SetUpdatedBy(run, user);
+        dbContext.WorkflowRuns.Add(run);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return run;
+    }
+
+    private ProjectIdentificationSetupResponse CreateSetupResponse(
+        WorkflowRun run,
+        IReadOnlyDictionary<string, RecentImportResponse> latestImports)
+    {
+        var items = CreateChecklistItems(run, latestImports);
+        var completedCount = items.Count(item => item.Completed);
+
+        return new ProjectIdentificationSetupResponse(
+            run.Id,
+            run.FiscalYear,
+            run.CycleStart,
+            run.CycleEnd,
+            CreateFiscalPeriodOptions(run.FiscalYear),
+            completedCount,
+            items.Count,
+            items);
+    }
+
+    private static IReadOnlyList<FiscalPeriodOptionDto> CreateFiscalPeriodOptions(string selectedFiscalYear)
+    {
+        var current = CurrentFiscalYearCycle();
+        var selectedYear = ParseFiscalYearNumber(selectedFiscalYear) ?? ParseFiscalYearNumber(current.FiscalYear)!.Value;
+        var currentYear = ParseFiscalYearNumber(current.FiscalYear)!.Value;
+        var years = new[] { currentYear - 1, currentYear, currentYear + 1, selectedYear }
+            .Distinct()
+            .Order()
+            .ToList();
+
+        return years
+            .Select(year =>
+            {
+                var fiscalYear = $"FY{year % 100:00}";
+                FiscalYearCycle.TryParse(fiscalYear, out var cycle);
+                return new FiscalPeriodOptionDto(
+                    cycle!.FiscalYear,
+                    cycle.CycleStart,
+                    cycle.CycleEnd,
+                    $"{cycle.FiscalYear.Replace("FY", "FY:")} - {FormatPeriod(cycle)}");
+            })
+            .ToList();
+    }
+
+    private List<ProjectChecklistItemDto> CreateChecklistItems(
+        WorkflowRun run,
+        IReadOnlyDictionary<string, RecentImportResponse> latestImports)
+    {
+        var states = run.ChecklistItemStates
+            .ToDictionary(state => state.ItemId, StringComparer.OrdinalIgnoreCase);
+        var completedByItemId = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var response = new List<ProjectChecklistItemDto>();
+
+        foreach (var definition in ChecklistItems)
+        {
+            states.TryGetValue(definition.Id, out var state);
+            var previousComplete = ChecklistItems
+                .Where(item => item.Number < definition.Number)
+                .All(item => completedByItemId.GetValueOrDefault(item.Id));
+            var ready = IsReady(definition, state, latestImports);
+            var completed = IsEffectivelyComplete(definition, state, latestImports);
+            var stale = IsStale(definition, state, latestImports, out var staleReason);
+            var status = GetStatus(definition, previousComplete, ready, completed, stale);
+            var latestImport = DatasetByItemId.TryGetValue(definition.Id, out var datasetId)
+                ? latestImports.GetValueOrDefault(datasetId)
+                : null;
+
+            completedByItemId[definition.Id] = completed;
+            response.Add(new ProjectChecklistItemDto(
+                definition.Id,
+                definition.Number,
+                definition.Label,
+                definition.Hint,
+                definition.Kind,
+                status,
+                completed,
+                ready,
+                stale,
+                staleReason,
+                latestImport,
+                state is null
+                    ? null
+                    : new ProjectChecklistSourceDto(
+                        state.SourceImportLogId,
+                        state.SourceKey,
+                        state.SourceRows,
+                        state.SourceCompletedAt)));
+        }
+
+        return response;
+    }
+
+    private static string GetStatus(
+        ChecklistItemDefinition definition,
+        bool previousComplete,
+        bool ready,
+        bool completed,
+        bool stale)
+    {
+        if (completed)
+        {
+            return "done";
+        }
+
+        if (stale)
+        {
+            return "stale";
+        }
+
+        if (definition.Id == FinalizeProjectsItemId || !previousComplete)
+        {
+            return "locked";
+        }
+
+        if (!ready || definition.Id == FiscalPeriodItemId)
+        {
+            return "active";
+        }
+
+        return "ready";
+    }
+
+    private static bool IsReady(
+        ChecklistItemDefinition definition,
+        WorkflowChecklistItemState? state,
+        IReadOnlyDictionary<string, RecentImportResponse> latestImports)
+    {
+        if (definition.Id == FiscalPeriodItemId || definition.Id == ResolveIssuesItemId)
+        {
+            return true;
+        }
+
+        if (definition.Id == FinalizeProjectsItemId)
+        {
+            return false;
+        }
+
+        if (DatasetByItemId.TryGetValue(definition.Id, out var datasetId))
+        {
+            var latestImport = latestImports.GetValueOrDefault(datasetId);
+            return latestImport is not null && IsSucceeded(latestImport);
+        }
+
+        return definition.Id == PgmItemId && state?.SourceRows is not null && state.SourceCompletedAt is not null;
+    }
+
+    private static bool IsEffectivelyComplete(
+        ChecklistItemDefinition definition,
+        WorkflowChecklistItemState? state,
+        IReadOnlyDictionary<string, RecentImportResponse> latestImports)
+    {
+        if (state?.CompletedAt is null || definition.Id == FinalizeProjectsItemId)
+        {
+            return false;
+        }
+
+        if (DatasetByItemId.TryGetValue(definition.Id, out var datasetId))
+        {
+            var latestImport = latestImports.GetValueOrDefault(datasetId);
+            return latestImport is not null
+                && IsSucceeded(latestImport)
+                && state.SourceImportLogId == latestImport.Id;
+        }
+
+        if (definition.Id == PgmItemId)
+        {
+            return state.SourceRows is not null && state.SourceCompletedAt is not null;
+        }
+
+        return true;
+    }
+
+    private static bool IsStale(
+        ChecklistItemDefinition definition,
+        WorkflowChecklistItemState? state,
+        IReadOnlyDictionary<string, RecentImportResponse> latestImports,
+        out string? reason)
+    {
+        reason = null;
+
+        if (state?.CompletedAt is null || !DatasetByItemId.TryGetValue(definition.Id, out var datasetId))
+        {
+            return false;
+        }
+
+        var latestImport = latestImports.GetValueOrDefault(datasetId);
+        if (latestImport is null)
+        {
+            reason = "The import used to complete this item is no longer available.";
+            return true;
+        }
+
+        if (!IsSucceeded(latestImport))
+        {
+            reason = "The latest import attempt did not succeed.";
+            return true;
+        }
+
+        if (state.SourceImportLogId != latestImport.Id)
+        {
+            reason = "A newer import has been uploaded since this item was marked done.";
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task<IReadOnlyDictionary<string, RecentImportResponse>> GetLatestImportsAsync(
+        CancellationToken cancellationToken)
+    {
+        var datasetIds = importRegistry.Datasets.Select(dataset => dataset.Id).ToList();
+        var recentLogs = await dbContext.ImportLogs
+            .AsNoTracking()
+            .Where(log => datasetIds.Contains(log.Dataset))
+            .Where(log => log.Id == dbContext.ImportLogs
+                .Where(candidate => candidate.Dataset == log.Dataset)
+                .OrderByDescending(candidate => candidate.CompletedAt)
+                .ThenByDescending(candidate => candidate.Id)
+                .Select(candidate => candidate.Id)
+                .First())
+            .ToListAsync(cancellationToken);
+
+        return recentLogs.ToDictionary(
+            log => log.Dataset,
+            log => new RecentImportResponse(
+                log.Id,
+                log.Dataset,
+                log.Filename,
+                log.Status,
+                log.AttemptedRows,
+                log.RowsImported,
+                log.CompletedAt,
+                log.UploadedByName,
+                log.UploadedByEmail,
+                DeserializeValidationStats(log.ErrorPayload)),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static ImportValidationStatsResponse? DeserializeValidationStats(string? errorPayload)
+    {
+        if (string.IsNullOrWhiteSpace(errorPayload))
+        {
+            return null;
+        }
+
+        try
+        {
+            var payload = JsonSerializer.Deserialize<ImportValidationHistoryReadModel>(errorPayload);
+            if (payload is null)
+            {
+                return null;
+            }
+
+            return new ImportValidationStatsResponse(
+                payload.RowCount,
+                payload.RowsWithErrors,
+                payload.ErrorCount,
+                payload.FileErrors.Count);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static WorkflowChecklistItemState GetOrCreateState(WorkflowRun run, string itemId)
+    {
+        var state = run.ChecklistItemStates.SingleOrDefault(item =>
+            string.Equals(item.ItemId, itemId, StringComparison.OrdinalIgnoreCase));
+
+        if (state is not null)
+        {
+            return state;
+        }
+
+        state = new WorkflowChecklistItemState
+        {
+            ItemId = itemId,
+            WorkflowRun = run,
+            WorkflowRunId = run.Id,
+        };
+        run.ChecklistItemStates.Add(state);
+        return state;
+    }
+
+    private static void CompleteState(
+        WorkflowChecklistItemState state,
+        ClaimsPrincipal user,
+        DateTimeOffset completedAt)
+    {
+        state.CompletedAt = completedAt;
+        state.CompletedByEntraId = user.GetEntraId();
+        state.CompletedByName = Truncate(user.FindFirst("name")?.Value ?? user.Identity?.Name, 200);
+        state.CompletedByEmail = Truncate(
+            user.FindFirst("preferred_username")?.Value ?? user.FindFirst(ClaimTypes.Email)?.Value,
+            320);
+    }
+
+    private static void ClearFrom(WorkflowRun run, int number)
+    {
+        var itemIds = ChecklistItems
+            .Where(item => item.Number >= number)
+            .Select(item => item.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        run.ChecklistItemStates.RemoveAll(state => itemIds.Contains(state.ItemId));
+    }
+
+    private static void ClearAfter(WorkflowRun run, int number)
+    {
+        var itemIds = ChecklistItems
+            .Where(item => item.Number > number)
+            .Select(item => item.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        run.ChecklistItemStates.RemoveAll(state => itemIds.Contains(state.ItemId));
+    }
+
+    private static ChecklistItemDefinition? FindDefinition(string itemId) =>
+        ChecklistItems.SingleOrDefault(item =>
+            string.Equals(item.Id, itemId, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsSucceeded(RecentImportResponse import) =>
+        string.Equals(import.Status, "Succeeded", StringComparison.OrdinalIgnoreCase);
+
+    private static FiscalYearCycle CurrentFiscalYearCycle()
+    {
+        var now = DateTimeOffset.Now;
+        var calendarYear = now.Year;
+        var fiscalYear = now.Month >= 10 ? calendarYear + 1 : calendarYear;
+        var fiscalYearText = $"FY{fiscalYear % 100:00}";
+        FiscalYearCycle.TryParse(fiscalYearText, out var cycle);
+        return cycle!;
+    }
+
+    private static int? ParseFiscalYearNumber(string fiscalYear)
+    {
+        var normalized = fiscalYear.Replace("FY:", "FY", StringComparison.OrdinalIgnoreCase);
+        if (normalized.StartsWith("FY", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(normalized[2..], out var year))
+        {
+            return 2000 + year;
+        }
+
+        return null;
+    }
+
+    private static string FormatPeriod(FiscalYearCycle cycle) =>
+        $"{cycle.CycleStart:MMM yyyy} - {cycle.CycleEnd:MMM yyyy}";
+
+    private static void Touch(WorkflowRun run, ClaimsPrincipal user, DateTimeOffset updatedAt)
+    {
+        run.UpdatedAt = updatedAt;
+        SetUpdatedBy(run, user);
+    }
+
+    private static void SetCreatedBy(WorkflowRun run, ClaimsPrincipal user)
+    {
+        run.CreatedByEntraId = user.GetEntraId();
+        run.CreatedByName = Truncate(user.FindFirst("name")?.Value ?? user.Identity?.Name, 200);
+        run.CreatedByEmail = Truncate(
+            user.FindFirst("preferred_username")?.Value ?? user.FindFirst(ClaimTypes.Email)?.Value,
+            320);
+    }
+
+    private static void SetUpdatedBy(WorkflowRun run, ClaimsPrincipal user)
+    {
+        run.UpdatedByEntraId = user.GetEntraId();
+        run.UpdatedByName = Truncate(user.FindFirst("name")?.Value ?? user.Identity?.Name, 200);
+        run.UpdatedByEmail = Truncate(
+            user.FindFirst("preferred_username")?.Value ?? user.FindFirst(ClaimTypes.Email)?.Value,
+            320);
+    }
+
+    private static string? Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        return value[..maxLength];
+    }
+
+    private sealed record ChecklistItemDefinition(
+        string Id,
+        int Number,
+        string Label,
+        string Hint,
+        string Kind);
+
+    private sealed class ImportValidationHistoryReadModel
+    {
+        public int RowCount { get; set; }
+        public int RowsWithErrors { get; set; }
+        public int ErrorCount { get; set; }
+        public List<ImportFileError> FileErrors { get; set; } = [];
+    }
+}

--- a/server/ProjectIdentification/ProjectIdentificationService.cs
+++ b/server/ProjectIdentification/ProjectIdentificationService.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Server.Authorization;
 using Server.Core.Data;
@@ -63,7 +64,7 @@ public sealed class ProjectIdentificationService(
 
         var run = await GetOrCreateCurrentRunAsync(user, cancellationToken);
         var now = DateTimeOffset.UtcNow;
-        var changed = !string.Equals(run.FiscalYear, cycle!.FiscalYear, StringComparison.OrdinalIgnoreCase);
+        var changed = !string.Equals(run.FiscalYear, cycle.FiscalYear, StringComparison.OrdinalIgnoreCase);
 
         if (changed)
         {
@@ -172,7 +173,7 @@ public sealed class ProjectIdentificationService(
             return false;
         }
 
-        var projectList = await projectListService.GetAsync(cycle!, cancellationToken);
+        var projectList = await projectListService.GetAsync(cycle, cancellationToken);
         return projectList.Summary.IssuesToResolve == 0;
     }
 
@@ -203,11 +204,7 @@ public sealed class ProjectIdentificationService(
         ClaimsPrincipal user,
         CancellationToken cancellationToken)
     {
-        var run = await dbContext.WorkflowRuns
-            .Include(item => item.ChecklistItemStates)
-            .Where(item => item.IsCurrent)
-            .OrderByDescending(item => item.CreatedAt)
-            .FirstOrDefaultAsync(cancellationToken);
+        var run = await GetCurrentRunAsync(cancellationToken);
 
         if (run is not null)
         {
@@ -229,9 +226,25 @@ public sealed class ProjectIdentificationService(
         SetCreatedBy(run, user);
         SetUpdatedBy(run, user);
         dbContext.WorkflowRuns.Add(run);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return run;
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return run;
+        }
+        catch (DbUpdateException ex) when (IsCurrentRunUniquenessViolation(ex))
+        {
+            dbContext.Entry(run).State = EntityState.Detached;
+            return await GetCurrentRunAsync(cancellationToken)
+                ?? throw new InvalidOperationException("A current workflow run already exists but could not be loaded.", ex);
+        }
     }
+
+    private Task<WorkflowRun?> GetCurrentRunAsync(CancellationToken cancellationToken) =>
+        dbContext.WorkflowRuns
+            .Include(item => item.ChecklistItemStates)
+            .Where(item => item.IsCurrent)
+            .OrderByDescending(item => item.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
 
     private ProjectIdentificationSetupResponse CreateSetupResponse(
         WorkflowRun run,
@@ -254,8 +267,9 @@ public sealed class ProjectIdentificationService(
     private static IReadOnlyList<FiscalPeriodOptionDto> CreateFiscalPeriodOptions(string selectedFiscalYear)
     {
         var current = CurrentFiscalYearCycle();
-        var selectedYear = ParseFiscalYearNumber(selectedFiscalYear) ?? ParseFiscalYearNumber(current.FiscalYear)!.Value;
-        var currentYear = ParseFiscalYearNumber(current.FiscalYear)!.Value;
+        var currentYear = ParseFiscalYearNumber(current.FiscalYear)
+            ?? throw new InvalidOperationException($"Current fiscal year '{current.FiscalYear}' could not be parsed.");
+        var selectedYear = ParseFiscalYearNumber(selectedFiscalYear) ?? currentYear;
         var years = new[] { currentYear - 1, currentYear, currentYear + 1, selectedYear }
             .Distinct()
             .Order()
@@ -265,9 +279,13 @@ public sealed class ProjectIdentificationService(
             .Select(year =>
             {
                 var fiscalYear = $"FY{year % 100:00}";
-                FiscalYearCycle.TryParse(fiscalYear, out var cycle);
+                if (!FiscalYearCycle.TryParse(fiscalYear, out var cycle))
+                {
+                    throw new InvalidOperationException($"Fiscal year option '{fiscalYear}' could not be parsed.");
+                }
+
                 return new FiscalPeriodOptionDto(
-                    cycle!.FiscalYear,
+                    cycle.FiscalYear,
                     cycle.CycleStart,
                     cycle.CycleEnd,
                     $"{cycle.FiscalYear.Replace("FY", "FY:")} - {FormatPeriod(cycle)}");
@@ -442,31 +460,37 @@ public sealed class ProjectIdentificationService(
         CancellationToken cancellationToken)
     {
         var datasetIds = importRegistry.Datasets.Select(dataset => dataset.Id).ToList();
-        var recentLogs = await dbContext.ImportLogs
-            .AsNoTracking()
-            .Where(log => datasetIds.Contains(log.Dataset))
-            .Where(log => log.Id == dbContext.ImportLogs
-                .Where(candidate => candidate.Dataset == log.Dataset)
-                .OrderByDescending(candidate => candidate.CompletedAt)
-                .ThenByDescending(candidate => candidate.Id)
-                .Select(candidate => candidate.Id)
-                .First())
-            .ToListAsync(cancellationToken);
+        var recentLogs = new List<ImportLog>();
+        foreach (var datasetId in datasetIds)
+        {
+            var recentLog = await dbContext.ImportLogs
+                .AsNoTracking()
+                .Where(log => log.Dataset == datasetId)
+                .OrderByDescending(log => log.CompletedAt)
+                .ThenByDescending(log => log.Id)
+                .FirstOrDefaultAsync(cancellationToken);
 
-        return recentLogs.ToDictionary(
-            log => log.Dataset,
-            log => new RecentImportResponse(
-                log.Id,
-                log.Dataset,
-                log.Filename,
-                log.Status,
-                log.AttemptedRows,
-                log.RowsImported,
-                log.CompletedAt,
-                log.UploadedByName,
-                log.UploadedByEmail,
-                DeserializeValidationStats(log.ErrorPayload)),
-            StringComparer.OrdinalIgnoreCase);
+            if (recentLog is not null)
+            {
+                recentLogs.Add(recentLog);
+            }
+        }
+
+        return recentLogs
+            .ToDictionary(
+                log => log.Dataset,
+                log => new RecentImportResponse(
+                    log.Id,
+                    log.Dataset,
+                    log.Filename,
+                    log.Status,
+                    log.AttemptedRows,
+                    log.RowsImported,
+                    log.CompletedAt,
+                    log.UploadedByName,
+                    log.UploadedByEmail,
+                    DeserializeValidationStats(log.ErrorPayload)),
+                StringComparer.OrdinalIgnoreCase);
     }
 
     private static ImportValidationStatsResponse? DeserializeValidationStats(string? errorPayload)
@@ -562,9 +586,17 @@ public sealed class ProjectIdentificationService(
         var calendarYear = now.Year;
         var fiscalYear = now.Month >= 10 ? calendarYear + 1 : calendarYear;
         var fiscalYearText = $"FY{fiscalYear % 100:00}";
-        FiscalYearCycle.TryParse(fiscalYearText, out var cycle);
-        return cycle!;
+        if (!FiscalYearCycle.TryParse(fiscalYearText, out var cycle))
+        {
+            throw new InvalidOperationException($"Current fiscal year '{fiscalYearText}' could not be parsed.");
+        }
+
+        return cycle;
     }
+
+    private static bool IsCurrentRunUniquenessViolation(DbUpdateException exception) =>
+        exception.GetBaseException() is SqlException sqlException
+        && sqlException.Errors.Cast<SqlError>().Any(error => error.Number is 2601 or 2627);
 
     private static int? ParseFiscalYearNumber(string fiscalYear)
     {

--- a/server/ProjectList/IProjectListService.cs
+++ b/server/ProjectList/IProjectListService.cs
@@ -1,0 +1,9 @@
+using Server.Models.ProjectList;
+using Server.Models;
+
+namespace Server.ProjectList;
+
+public interface IProjectListService
+{
+    Task<ProjectListResponse> GetAsync(FiscalYearCycle cycle, CancellationToken cancellationToken);
+}

--- a/server/ProjectList/ProjectListResponseFactory.cs
+++ b/server/ProjectList/ProjectListResponseFactory.cs
@@ -1,0 +1,41 @@
+using Server.Models.ProjectList;
+using Server.Models;
+
+namespace Server.ProjectList;
+
+public static class ProjectListResponseFactory
+{
+    private const string CleanStatus = "Clean";
+
+    public static ProjectListResponse Create(
+        FiscalYearCycle cycle,
+        IReadOnlyList<ProjectListRowDto> rows,
+        int activeNifa,
+        int allNifa,
+        int pgmRecords,
+        int alnCodes)
+    {
+        var issues = rows.Count(row => row.Status != CleanStatus);
+        var clean = rows.Count(row => row.Status == CleanStatus);
+        var sfnDistribution = rows
+            .Where(row => !string.IsNullOrWhiteSpace(row.Sfn))
+            .GroupBy(row => row.Sfn!)
+            .OrderBy(group => group.Key)
+            .Select(group => new SfnDistributionDto(group.Key, group.Count()))
+            .ToList();
+
+        return new ProjectListResponse(
+            cycle.FiscalYear,
+            cycle.CycleStart,
+            cycle.CycleEnd,
+            new ProjectListCountsDto(issues, clean, rows.Count),
+            new ProjectListSummaryDto(
+                activeNifa,
+                allNifa,
+                pgmRecords,
+                alnCodes,
+                issues,
+                sfnDistribution),
+            rows);
+    }
+}

--- a/server/ProjectList/ProjectListService.cs
+++ b/server/ProjectList/ProjectListService.cs
@@ -1,0 +1,83 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Server.Core.Data;
+using Server.Models;
+using Server.Models.ProjectList;
+
+namespace Server.ProjectList;
+
+public sealed class ProjectListService(
+    DataDbContext dataDbContext,
+    IConfiguration configuration) : IProjectListService
+{
+    public async Task<ProjectListResponse> GetAsync(FiscalYearCycle cycle, CancellationToken cancellationToken)
+    {
+        var connectionString = DataDbConnection.Resolve(
+            configuration,
+            dataDbContext.Database.GetConnectionString());
+
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        var rows = (await connection.QueryAsync<ProjectListRowDto>(new CommandDefinition(
+            "[data].[GetProjectList]",
+            new
+            {
+                cycleStart = cycle.CycleStart.ToDateTime(TimeOnly.MinValue),
+                cycleEnd = cycle.CycleEnd.ToDateTime(TimeOnly.MinValue),
+            },
+            commandType: CommandType.StoredProcedure,
+            commandTimeout: DataDbConnection.ImportCommandTimeoutSeconds,
+            cancellationToken: cancellationToken))).ToList();
+
+        var summaryCounts = await connection.QuerySingleAsync<ProjectListSummaryCounts>(new CommandDefinition(
+            SummaryCountsSql,
+            new
+            {
+                cycleStart = cycle.CycleStart.ToDateTime(TimeOnly.MinValue),
+                cycleEnd = cycle.CycleEnd.ToDateTime(TimeOnly.MinValue),
+            },
+            commandTimeout: DataDbConnection.ImportCommandTimeoutSeconds,
+            cancellationToken: cancellationToken));
+
+        return ProjectListResponseFactory.Create(
+            cycle,
+            rows,
+            summaryCounts.ActiveNifa,
+            summaryCounts.AllNifa,
+            summaryCounts.PgmRecords,
+            summaryCounts.AlnCodes);
+    }
+
+    private const string SummaryCountsSql = """
+        SELECT
+            ActiveNifa = (
+                SELECT COUNT(*)
+                FROM [data].[ActiveProjects]
+                WHERE ISNULL([ExcludeFromUi], 0) = 0
+            ),
+            AllNifa = (
+                SELECT COUNT(*)
+                FROM [data].[AllProjects]
+                WHERE ([ProjectEndDate] IS NULL OR [ProjectEndDate] >= @cycleStart)
+                  AND ([ProjectStartDate] IS NULL OR [ProjectStartDate] <= @cycleEnd)
+            ),
+            PgmRecords = (
+                SELECT COUNT(*)
+                FROM [data].[PGMProjects]
+            ),
+            AlnCodes = (
+                SELECT COUNT(*)
+                FROM [data].[AssistanceListingNumbers]
+                WHERE [ProgramNumber] IS NOT NULL
+            );
+        """;
+
+    private sealed record ProjectListSummaryCounts(
+        int ActiveNifa,
+        int AllNifa,
+        int PgmRecords,
+        int AlnCodes);
+}

--- a/tests/server.tests/Data/AppDbContextTests.cs
+++ b/tests/server.tests/Data/AppDbContextTests.cs
@@ -57,6 +57,30 @@ public class AppDbContextTests
     }
 
     [Fact]
+    public void WorkflowRun_maps_to_app_schema()
+    {
+        using var db = TestDbContextFactory.CreateInMemory();
+
+        var entityType = db.Model.FindEntityType(typeof(WorkflowRun));
+
+        entityType.Should().NotBeNull();
+        entityType!.GetSchema().Should().Be(AppDbContext.AppSchema);
+        entityType.GetTableName().Should().Be("WorkflowRun");
+    }
+
+    [Fact]
+    public void WorkflowChecklistItemState_maps_to_app_schema()
+    {
+        using var db = TestDbContextFactory.CreateInMemory();
+
+        var entityType = db.Model.FindEntityType(typeof(WorkflowChecklistItemState));
+
+        entityType.Should().NotBeNull();
+        entityType!.GetSchema().Should().Be(AppDbContext.AppSchema);
+        entityType.GetTableName().Should().Be("WorkflowChecklistItemState");
+    }
+
+    [Fact]
     public void ImportLog_has_index_for_latest_log_by_dataset()
     {
         using var db = TestDbContextFactory.CreateInMemory();
@@ -72,6 +96,23 @@ public class AppDbContextTests
 
         latestByDatasetIndex.Should().NotBeNull();
         latestByDatasetIndex!.IsDescending.Should().Equal([false, true, true]);
+    }
+
+    [Fact]
+    public void WorkflowChecklistItemState_has_unique_index_per_run_and_item()
+    {
+        using var db = TestDbContextFactory.CreateInMemory();
+
+        var entityType = db.GetService<IDesignTimeModel>().Model.FindEntityType(typeof(WorkflowChecklistItemState));
+        var index = entityType?.GetIndexes()
+            .SingleOrDefault(item => item.Properties.Select(property => property.Name)
+                .SequenceEqual([
+                    nameof(WorkflowChecklistItemState.WorkflowRunId),
+                    nameof(WorkflowChecklistItemState.ItemId),
+                ]));
+
+        index.Should().NotBeNull();
+        index!.IsUnique.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/server.tests/Data/AppDbContextTests.cs
+++ b/tests/server.tests/Data/AppDbContextTests.cs
@@ -116,6 +116,38 @@ public class AppDbContextTests
     }
 
     [Fact]
+    public void WorkflowRun_has_filtered_unique_index_for_current_run()
+    {
+        using var db = TestDbContextFactory.CreateInMemory();
+
+        var entityType = db.GetService<IDesignTimeModel>().Model.FindEntityType(typeof(WorkflowRun));
+        var index = entityType?.GetIndexes()
+            .SingleOrDefault(item => item.Properties.Select(property => property.Name)
+                .SequenceEqual([nameof(WorkflowRun.IsCurrent)]));
+
+        index.Should().NotBeNull();
+        index!.IsUnique.Should().BeTrue();
+        index.GetFilter().Should().Be("[IsCurrent] = 1");
+    }
+
+    [Fact]
+    public void WorkflowChecklistItemState_has_optional_source_import_log_relationship()
+    {
+        using var db = TestDbContextFactory.CreateInMemory();
+
+        var entityType = db.Model.FindEntityType(typeof(WorkflowChecklistItemState));
+        var foreignKey = entityType?.FindNavigation(nameof(WorkflowChecklistItemState.SourceImportLog))
+            ?.ForeignKey;
+
+        foreignKey.Should().NotBeNull();
+        foreignKey!.PrincipalEntityType.ClrType.Should().Be(typeof(ImportLog));
+        foreignKey.Properties.Should().ContainSingle(property =>
+            property.Name == nameof(WorkflowChecklistItemState.SourceImportLogId));
+        foreignKey.DeleteBehavior.Should().Be(DeleteBehavior.SetNull);
+        foreignKey.IsRequired.Should().BeFalse();
+    }
+
+    [Fact]
     public void User_has_unique_index_on_entra_id()
     {
         using var db = TestDbContextFactory.CreateInMemory();

--- a/tests/server.tests/Import/PgmProjectsControllerTests.cs
+++ b/tests/server.tests/Import/PgmProjectsControllerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using Server.Controllers;
 using Server.Core.Import;
 using Server.Models.ProjectIdentification;
@@ -15,7 +16,10 @@ public class PgmProjectsControllerTests
     {
         var importService = new FakeImportService();
         var projectIdentificationService = new FakeProjectIdentificationService();
-        var controller = new PgmProjectsController(importService, projectIdentificationService);
+        var controller = new PgmProjectsController(
+            importService,
+            projectIdentificationService,
+            NullLogger<PgmProjectsController>.Instance);
 
         var result = await controller.Import(null, CancellationToken.None);
 
@@ -29,7 +33,32 @@ public class PgmProjectsControllerTests
     {
         var importService = new FakeImportService();
         var projectIdentificationService = new FakeProjectIdentificationService();
-        var controller = new PgmProjectsController(importService, projectIdentificationService);
+        var controller = new PgmProjectsController(
+            importService,
+            projectIdentificationService,
+            NullLogger<PgmProjectsController>.Instance);
+        var reportDate = new DateOnly(2026, 6, 30);
+
+        var result = await controller.Import(reportDate, CancellationToken.None);
+
+        importService.Invocations.Should().Equal(reportDate);
+        projectIdentificationService.RecordedResults.Should().Equal(new PgmProjectsImportResult(42, reportDate));
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeEquivalentTo(new PgmProjectsImportResult(42, reportDate));
+    }
+
+    [Fact]
+    public async Task Import_returns_ok_when_workflow_recording_fails_after_import_succeeds()
+    {
+        var importService = new FakeImportService();
+        var projectIdentificationService = new FakeProjectIdentificationService
+        {
+            ThrowOnRecord = true,
+        };
+        var controller = new PgmProjectsController(
+            importService,
+            projectIdentificationService,
+            NullLogger<PgmProjectsController>.Instance);
         var reportDate = new DateOnly(2026, 6, 30);
 
         var result = await controller.Import(reportDate, CancellationToken.None);
@@ -54,6 +83,7 @@ public class PgmProjectsControllerTests
     private sealed class FakeProjectIdentificationService : IProjectIdentificationService
     {
         public List<PgmProjectsImportResult> RecordedResults { get; } = [];
+        public bool ThrowOnRecord { get; init; }
 
         public Task<ProjectIdentificationSetupResponse> GetSetupAsync(
             ClaimsPrincipal user,
@@ -79,6 +109,11 @@ public class PgmProjectsControllerTests
             CancellationToken cancellationToken)
         {
             RecordedResults.Add(result);
+            if (ThrowOnRecord)
+            {
+                throw new InvalidOperationException("Workflow recording failed.");
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/tests/server.tests/Import/PgmProjectsControllerTests.cs
+++ b/tests/server.tests/Import/PgmProjectsControllerTests.cs
@@ -2,6 +2,9 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Server.Controllers;
 using Server.Core.Import;
+using Server.Models.ProjectIdentification;
+using Server.ProjectIdentification;
+using System.Security.Claims;
 
 namespace Server.Tests.Import;
 
@@ -11,24 +14,28 @@ public class PgmProjectsControllerTests
     public async Task Import_returns_bad_request_when_report_date_is_missing()
     {
         var importService = new FakeImportService();
-        var controller = new PgmProjectsController(importService);
+        var projectIdentificationService = new FakeProjectIdentificationService();
+        var controller = new PgmProjectsController(importService, projectIdentificationService);
 
         var result = await controller.Import(null, CancellationToken.None);
 
         result.Result.Should().BeOfType<BadRequestObjectResult>();
         importService.Invocations.Should().BeEmpty();
+        projectIdentificationService.RecordedResults.Should().BeEmpty();
     }
 
     [Fact]
     public async Task Import_runs_the_import_for_the_given_report_date()
     {
         var importService = new FakeImportService();
-        var controller = new PgmProjectsController(importService);
+        var projectIdentificationService = new FakeProjectIdentificationService();
+        var controller = new PgmProjectsController(importService, projectIdentificationService);
         var reportDate = new DateOnly(2026, 6, 30);
 
         var result = await controller.Import(reportDate, CancellationToken.None);
 
         importService.Invocations.Should().Equal(reportDate);
+        projectIdentificationService.RecordedResults.Should().Equal(new PgmProjectsImportResult(42, reportDate));
         result.Result.Should().BeOfType<OkObjectResult>()
             .Which.Value.Should().BeEquivalentTo(new PgmProjectsImportResult(42, reportDate));
     }
@@ -41,6 +48,38 @@ public class PgmProjectsControllerTests
         {
             Invocations.Add(reportDate);
             return Task.FromResult(new PgmProjectsImportResult(42, reportDate));
+        }
+    }
+
+    private sealed class FakeProjectIdentificationService : IProjectIdentificationService
+    {
+        public List<PgmProjectsImportResult> RecordedResults { get; } = [];
+
+        public Task<ProjectIdentificationSetupResponse> GetSetupAsync(
+            ClaimsPrincipal user,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<ProjectIdentificationSetupResponse?> ConfirmFiscalPeriodAsync(
+            string? fiscalYear,
+            ClaimsPrincipal user,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<ProjectIdentificationSetupResponse?> SetChecklistItemCompletionAsync(
+            string itemId,
+            bool completed,
+            ClaimsPrincipal user,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task RecordPgmImportAsync(
+            PgmProjectsImportResult result,
+            ClaimsPrincipal user,
+            CancellationToken cancellationToken)
+        {
+            RecordedResults.Add(result);
+            return Task.CompletedTask;
         }
     }
 }

--- a/tests/server.tests/Import/PgmProjectsImportServiceTests.cs
+++ b/tests/server.tests/Import/PgmProjectsImportServiceTests.cs
@@ -58,17 +58,21 @@ public class PgmProjectsImportServiceTests
     }
 
     [Fact]
-    public void BuildAggregateLengthCheckQuery_returns_numeric_aggregate_length_telemetry()
+    public void BuildAggregateLengthCheckQuery_returns_numeric_aggregate_byte_length_telemetry()
     {
         var query = PgmProjectsImportService.BuildAggregateLengthCheckQuery();
 
         query.Should().Contain("SELECT project_id,");
-        query.Should().Contain("LENGTH(LISTAGG(DISTINCT piperson, '; ')) AS pi_persons_length");
+        query.Should().Contain("OCTET_LENGTH(LISTAGG(DISTINCT piperson, '; ')) AS pi_persons_length");
+        query.Should().NotContain("            LENGTH(LISTAGG");
         query.Should().Contain("COALESCE(pi_persons_length, 0) AS pi_persons_length");
         query.Should().Contain("WHERE principal_investigator_names_length > 255");
         query.Should().Contain("OR pi_persons_length > 255");
         query.Should().NotContain("VARCHAR(8000)");
         query.Should().NotContain("WITHIN GROUP");
+
+        PgmProjectsImportService.PeopleAggregateTruncationWarningMessage.Should().Contain("{MaxLength}-byte");
+        PgmProjectsImportService.PeopleAggregateTruncationWarningMessage.Should().NotContain("character");
     }
 
     [Fact]

--- a/tests/server.tests/Import/PgmProjectsImportServiceTests.cs
+++ b/tests/server.tests/Import/PgmProjectsImportServiceTests.cs
@@ -45,8 +45,40 @@ public class PgmProjectsImportServiceTests
         var query = PgmProjectsImportService.BuildRemoteQuery();
 
         // unbounded LISTAGG is reported as a LOB, which EXEC ... AT cannot stream
-        query.Should().Contain("CAST(LISTAGG(DISTINCT piperson, '; ') AS VARCHAR(8000))");
+        query.Should().Contain("CAST(LISTAGG(DISTINCT piperson, '; ') AS VARCHAR(255))");
         query.Should().NotContain("WITHIN GROUP");
+    }
+
+    [Fact]
+    public void BuildAggregateLengthCheckCommandText_runs_a_parameterized_exec_at_against_redshift()
+    {
+        var command = PgmProjectsImportService.BuildAggregateLengthCheckCommandText();
+
+        command.Should().Contain("EXEC (@remoteQuery) AT [AE_Redshift_PROD]");
+    }
+
+    [Fact]
+    public void BuildAggregateLengthCheckQuery_returns_numeric_aggregate_length_telemetry()
+    {
+        var query = PgmProjectsImportService.BuildAggregateLengthCheckQuery();
+
+        query.Should().Contain("SELECT project_id,");
+        query.Should().Contain("LENGTH(LISTAGG(DISTINCT piperson, '; ')) AS pi_persons_length");
+        query.Should().Contain("COALESCE(pi_persons_length, 0) AS pi_persons_length");
+        query.Should().Contain("WHERE principal_investigator_names_length > 255");
+        query.Should().Contain("OR pi_persons_length > 255");
+        query.Should().NotContain("VARCHAR(8000)");
+        query.Should().NotContain("WITHIN GROUP");
+    }
+
+    [Fact]
+    public void BuildStoredAggregateLengthQuery_returns_destination_lengths_by_project()
+    {
+        var query = PgmProjectsImportService.BuildStoredAggregateLengthQuery();
+
+        query.Should().Contain("SELECT ProjectId,");
+        query.Should().Contain("COALESCE(DATALENGTH(PiPersons) / 2, 0) AS PiPersonsLength");
+        query.Should().Contain("FROM [data].[PGMProjects]");
     }
 
     [Fact]

--- a/tests/server.tests/Models/FiscalYearCycleTests.cs
+++ b/tests/server.tests/Models/FiscalYearCycleTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Server.Models;
+
+namespace Server.Tests.Models;
+
+public class FiscalYearCycleTests
+{
+    [Theory]
+    [InlineData("FY25", "FY25", 2024, 10, 1, 2025, 9, 30)]
+    [InlineData("fy26", "FY26", 2025, 10, 1, 2026, 9, 30)]
+    public void TryParse_maps_fiscal_year_to_cycle_dates(
+        string input,
+        string expectedFiscalYear,
+        int startYear,
+        int startMonth,
+        int startDay,
+        int endYear,
+        int endMonth,
+        int endDay)
+    {
+        var parsed = FiscalYearCycle.TryParse(input, out var cycle);
+
+        parsed.Should().BeTrue();
+        cycle.Should().NotBeNull();
+        cycle!.FiscalYear.Should().Be(expectedFiscalYear);
+        cycle.CycleStart.Should().Be(new DateOnly(startYear, startMonth, startDay));
+        cycle.CycleEnd.Should().Be(new DateOnly(endYear, endMonth, endDay));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("FY")]
+    [InlineData("2027")]
+    [InlineData("fall-2026")]
+    public void TryParse_rejects_missing_or_invalid_values(string? input)
+    {
+        FiscalYearCycle.TryParse(input, out var cycle).Should().BeFalse();
+        cycle.Should().BeNull();
+    }
+}

--- a/tests/server.tests/Models/FiscalYearCycleTests.cs
+++ b/tests/server.tests/Models/FiscalYearCycleTests.cs
@@ -24,8 +24,7 @@ public class FiscalYearCycleTests
         var parsed = FiscalYearCycle.TryParse(input, out var cycle);
 
         parsed.Should().BeTrue();
-        cycle.Should().NotBeNull();
-        cycle!.FiscalYear.Should().Be(expectedFiscalYear);
+        cycle.FiscalYear.Should().Be(expectedFiscalYear);
         cycle.CycleStart.Should().Be(new DateOnly(startYear, startMonth, startDay));
         cycle.CycleEnd.Should().Be(new DateOnly(endYear, endMonth, endDay));
     }

--- a/tests/server.tests/Models/FiscalYearCycleTests.cs
+++ b/tests/server.tests/Models/FiscalYearCycleTests.cs
@@ -6,8 +6,11 @@ namespace Server.Tests.Models;
 public class FiscalYearCycleTests
 {
     [Theory]
+    [InlineData("FY00", "FY00", 1999, 10, 1, 2000, 9, 30)]
     [InlineData("FY25", "FY25", 2024, 10, 1, 2025, 9, 30)]
     [InlineData("fy26", "FY26", 2025, 10, 1, 2026, 9, 30)]
+    [InlineData("FY99", "FY99", 2098, 10, 1, 2099, 9, 30)]
+    [InlineData("FY2025", "FY25", 2024, 10, 1, 2025, 9, 30)]
     public void TryParse_maps_fiscal_year_to_cycle_dates(
         string input,
         string expectedFiscalYear,
@@ -33,6 +36,8 @@ public class FiscalYearCycleTests
     [InlineData("FY")]
     [InlineData("2027")]
     [InlineData("fall-2026")]
+    [InlineData("FY0001")]
+    [InlineData("FY10000")]
     public void TryParse_rejects_missing_or_invalid_values(string? input)
     {
         FiscalYearCycle.TryParse(input, out var cycle).Should().BeFalse();

--- a/tests/server.tests/Models/FiscalYearCycleTests.cs
+++ b/tests/server.tests/Models/FiscalYearCycleTests.cs
@@ -24,9 +24,10 @@ public class FiscalYearCycleTests
         var parsed = FiscalYearCycle.TryParse(input, out var cycle);
 
         parsed.Should().BeTrue();
-        cycle.FiscalYear.Should().Be(expectedFiscalYear);
-        cycle.CycleStart.Should().Be(new DateOnly(startYear, startMonth, startDay));
-        cycle.CycleEnd.Should().Be(new DateOnly(endYear, endMonth, endDay));
+        var parsedCycle = cycle ?? throw new InvalidOperationException("The fiscal year should parse.");
+        parsedCycle.FiscalYear.Should().Be(expectedFiscalYear);
+        parsedCycle.CycleStart.Should().Be(new DateOnly(startYear, startMonth, startDay));
+        parsedCycle.CycleEnd.Should().Be(new DateOnly(endYear, endMonth, endDay));
     }
 
     [Theory]

--- a/tests/server.tests/ProjectIdentification/ProjectIdentificationServiceTests.cs
+++ b/tests/server.tests/ProjectIdentification/ProjectIdentificationServiceTests.cs
@@ -1,0 +1,208 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Import;
+using Server.Models;
+using Server.Models.ProjectList;
+using Server.ProjectIdentification;
+using Server.ProjectList;
+
+namespace Server.Tests.ProjectIdentification;
+
+public class ProjectIdentificationServiceTests
+{
+    private static readonly ClaimsPrincipal User = new(new ClaimsIdentity(
+        [
+            new Claim("oid", "11111111-1111-1111-1111-111111111111"),
+            new Claim("name", "Shannon Taylor"),
+            new Claim("preferred_username", "shannon@example.edu"),
+        ],
+        "Test"));
+
+    [Fact]
+    public async Task Setup_creates_a_current_workflow_run_with_fiscal_period_active()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var service = CreateService(db);
+
+        var setup = await service.GetSetupAsync(User, CancellationToken.None);
+
+        setup.WorkflowRunId.Should().BePositive();
+        setup.TotalCount.Should().Be(7);
+        setup.CompletedCount.Should().Be(0);
+        setup.ChecklistItems[0].Id.Should().Be("fiscal-period");
+        setup.ChecklistItems[0].Status.Should().Be("active");
+        setup.ChecklistItems[1].Status.Should().Be("locked");
+        db.WorkflowRuns.Should().ContainSingle(run => run.IsCurrent);
+    }
+
+    [Fact]
+    public async Task ConfirmFiscalPeriod_completes_the_first_item()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var service = CreateService(db);
+
+        var setup = await service.ConfirmFiscalPeriodAsync("FY26", User, CancellationToken.None);
+
+        setup.Should().NotBeNull();
+        setup!.FiscalYear.Should().Be("FY26");
+        setup.CycleStart.Should().Be(new DateOnly(2025, 10, 1));
+        setup.CycleEnd.Should().Be(new DateOnly(2026, 9, 30));
+        setup.CompletedCount.Should().Be(1);
+        setup.ChecklistItems[0].Status.Should().Be("done");
+        setup.ChecklistItems[1].Status.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task Import_items_require_previous_completion_and_successful_latest_import()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var service = CreateService(db);
+        AddImport(db, "all-projects", 1, "Succeeded", 100, DateTimeOffset.Parse("2026-06-01T12:00:00Z"));
+        await db.SaveChangesAsync();
+
+        var blocked = await service.SetChecklistItemCompletionAsync("all-projects", true, User, CancellationToken.None);
+        blocked.Should().BeNull();
+
+        await service.ConfirmFiscalPeriodAsync("FY26", User, CancellationToken.None);
+        var setup = await service.SetChecklistItemCompletionAsync("all-projects", true, User, CancellationToken.None);
+
+        setup.Should().NotBeNull();
+        var allProjects = setup!.ChecklistItems.Single(item => item.Id == "all-projects");
+        allProjects.Status.Should().Be("done");
+        allProjects.Source!.ImportLogId.Should().Be(1);
+        setup.ChecklistItems.Single(item => item.Id == "active-projects").Status.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task Newer_import_attempt_makes_prior_completion_stale()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var service = CreateService(db);
+        AddImport(db, "all-projects", 1, "Succeeded", 100, DateTimeOffset.Parse("2026-06-01T12:00:00Z"));
+        await db.SaveChangesAsync();
+        await service.ConfirmFiscalPeriodAsync("FY26", User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("all-projects", true, User, CancellationToken.None);
+
+        AddImport(db, "all-projects", 2, "Succeeded", 110, DateTimeOffset.Parse("2026-06-02T12:00:00Z"));
+        await db.SaveChangesAsync();
+
+        var setup = await service.GetSetupAsync(User, CancellationToken.None);
+
+        var allProjects = setup.ChecklistItems.Single(item => item.Id == "all-projects");
+        allProjects.Completed.Should().BeFalse();
+        allProjects.Stale.Should().BeTrue();
+        allProjects.Status.Should().Be("stale");
+        allProjects.StaleReason.Should().Contain("newer import");
+    }
+
+    [Fact]
+    public async Task Pgm_import_result_makes_pgm_item_ready_but_not_complete()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var service = CreateService(db);
+
+        AddImport(db, "all-projects", 1, "Succeeded", 100, DateTimeOffset.Parse("2026-06-01T12:00:00Z"));
+        AddImport(db, "active-projects", 2, "Succeeded", 50, DateTimeOffset.Parse("2026-06-01T12:01:00Z"));
+        AddImport(db, "assistance-listing-numbers", 3, "Succeeded", 200, DateTimeOffset.Parse("2026-06-01T12:02:00Z"));
+        await db.SaveChangesAsync();
+
+        await service.ConfirmFiscalPeriodAsync("FY26", User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("all-projects", true, User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("active-projects", true, User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("assistance-listing-numbers", true, User, CancellationToken.None);
+        await service.RecordPgmImportAsync(
+            new PgmProjectsImportResult(1234, new DateOnly(2026, 9, 30)),
+            User,
+            CancellationToken.None);
+
+        var setup = await service.GetSetupAsync(User, CancellationToken.None);
+
+        var pgm = setup.ChecklistItems.Single(item => item.Id == "pgm-master-data");
+        pgm.Ready.Should().BeTrue();
+        pgm.Completed.Should().BeFalse();
+        pgm.Status.Should().Be("ready");
+        pgm.Source!.Rows.Should().Be(1234);
+    }
+
+    [Fact]
+    public async Task Resolve_issues_requires_current_project_list_to_have_no_issues()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var projectListService = new StubProjectListService { IssuesToResolve = 2 };
+        var service = CreateService(db, projectListService);
+
+        AddImport(db, "all-projects", 1, "Succeeded", 100, DateTimeOffset.Parse("2026-06-01T12:00:00Z"));
+        AddImport(db, "active-projects", 2, "Succeeded", 50, DateTimeOffset.Parse("2026-06-01T12:01:00Z"));
+        AddImport(db, "assistance-listing-numbers", 3, "Succeeded", 200, DateTimeOffset.Parse("2026-06-01T12:02:00Z"));
+        await db.SaveChangesAsync();
+
+        await service.ConfirmFiscalPeriodAsync("FY26", User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("all-projects", true, User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("active-projects", true, User, CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("assistance-listing-numbers", true, User, CancellationToken.None);
+        await service.RecordPgmImportAsync(
+            new PgmProjectsImportResult(1234, new DateOnly(2026, 9, 30)),
+            User,
+            CancellationToken.None);
+        await service.SetChecklistItemCompletionAsync("pgm-master-data", true, User, CancellationToken.None);
+
+        var blocked = await service.SetChecklistItemCompletionAsync(
+            "resolve-project-issues",
+            true,
+            User,
+            CancellationToken.None);
+        projectListService.IssuesToResolve = 0;
+        var completed = await service.SetChecklistItemCompletionAsync(
+            "resolve-project-issues",
+            true,
+            User,
+            CancellationToken.None);
+
+        blocked.Should().BeNull();
+        completed.Should().NotBeNull();
+        completed!.ChecklistItems.Single(item => item.Id == "resolve-project-issues")
+            .Status.Should().Be("done");
+    }
+
+    private static ProjectIdentificationService CreateService(
+        Server.Core.Data.AppDbContext db,
+        StubProjectListService? projectListService = null) =>
+        new(db, new FlatFileImportRegistry(), projectListService ?? new StubProjectListService());
+
+    private static void AddImport(
+        Server.Core.Data.AppDbContext db,
+        string dataset,
+        int id,
+        string status,
+        int rows,
+        DateTimeOffset completedAt)
+    {
+        db.ImportLogs.Add(new ImportLog
+        {
+            Id = id,
+            Dataset = dataset,
+            Filename = $"{dataset}-{id}.csv",
+            Status = status,
+            AttemptedRows = rows,
+            RowsImported = status == "Succeeded" ? rows : null,
+            StartedAt = completedAt.AddMinutes(-1),
+            CompletedAt = completedAt,
+        });
+    }
+
+    private sealed class StubProjectListService : IProjectListService
+    {
+        public int IssuesToResolve { get; set; }
+
+        public Task<ProjectListResponse> GetAsync(FiscalYearCycle cycle, CancellationToken cancellationToken) =>
+            Task.FromResult(new ProjectListResponse(
+                cycle.FiscalYear,
+                cycle.CycleStart,
+                cycle.CycleEnd,
+                new ProjectListCountsDto(IssuesToResolve, 0, IssuesToResolve),
+                new ProjectListSummaryDto(0, 0, 0, 0, IssuesToResolve, []),
+                []));
+    }
+}

--- a/tests/server.tests/ProjectList/ProjectListControllerTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListControllerTests.cs
@@ -13,6 +13,7 @@ public class ProjectListControllerTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("twenty-six")]
+    [InlineData("FY10000")]
     public async Task Get_returns_bad_request_for_missing_or_invalid_fy(string? fy)
     {
         var controller = new ProjectListController(new StubProjectListService());

--- a/tests/server.tests/ProjectList/ProjectListControllerTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListControllerTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Server.Controllers;
+using Server.Models;
+using Server.Models.ProjectList;
+using Server.ProjectList;
+
+namespace Server.Tests.ProjectList;
+
+public class ProjectListControllerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("twenty-six")]
+    public async Task Get_returns_bad_request_for_missing_or_invalid_fy(string? fy)
+    {
+        var controller = new ProjectListController(new StubProjectListService());
+
+        var result = await controller.Get(fy, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Get_passes_cycle_to_service_and_returns_response()
+    {
+        var service = new StubProjectListService();
+        var controller = new ProjectListController(service);
+
+        var result = await controller.Get("FY26", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeSameAs(service.Response);
+        service.ReceivedCycle.Should().Be(new FiscalYearCycle(
+            "FY26",
+            new DateOnly(2025, 10, 1),
+            new DateOnly(2026, 9, 30)));
+    }
+
+    private sealed class StubProjectListService : IProjectListService
+    {
+        public FiscalYearCycle? ReceivedCycle { get; private set; }
+
+        public ProjectListResponse Response { get; } = new(
+            "FY26",
+            new DateOnly(2025, 10, 1),
+            new DateOnly(2026, 9, 30),
+            new ProjectListCountsDto(1, 1, 2),
+            new ProjectListSummaryDto(2, 3, 4, 5, 1, []),
+            [
+                new ProjectListRowDto("CA-A-111-H", "1000001", "2025-1", "K1234", "Larkspur, S.", "ATM", "201", "Clean"),
+                new ProjectListRowDto("CA-B-222-CG", "1000002", "2025-2", null, "Okonkwo, Y.", "ANS", "204", "SFN mismatch"),
+            ]);
+
+        public Task<ProjectListResponse> GetAsync(FiscalYearCycle cycle, CancellationToken cancellationToken)
+        {
+            ReceivedCycle = cycle;
+            return Task.FromResult(Response);
+        }
+    }
+}

--- a/tests/server.tests/ProjectList/ProjectListControllerTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListControllerTests.cs
@@ -50,8 +50,28 @@ public class ProjectListControllerTests
             new ProjectListCountsDto(1, 1, 2),
             new ProjectListSummaryDto(2, 3, 4, 5, 1, []),
             [
-                new ProjectListRowDto("CA-A-111-H", "1000001", "2025-1", "K1234", "Larkspur, S.", "ATM", "201", "Clean"),
-                new ProjectListRowDto("CA-B-222-CG", "1000002", "2025-2", null, "Okonkwo, Y.", "ANS", "204", "SFN mismatch"),
+                new ProjectListRowDto(
+                    "CA-A-111-H",
+                    "1000001",
+                    "2025-1",
+                    "K1234",
+                    "Larkspur, S.",
+                    "10000001",
+                    "Larkspur, Sasha",
+                    "ATM",
+                    "201",
+                    "Clean"),
+                new ProjectListRowDto(
+                    "CA-B-222-CG",
+                    "1000002",
+                    "2025-2",
+                    null,
+                    "Okonkwo, Y.",
+                    "10000002",
+                    "Okonkwo, Yara",
+                    "ANS",
+                    "204",
+                    "SFN mismatch"),
             ]);
 
         public Task<ProjectListResponse> GetAsync(FiscalYearCycle cycle, CancellationToken cancellationToken)

--- a/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
@@ -10,7 +10,11 @@ public class ProjectListResponseFactoryTests
     [Fact]
     public void Create_counts_tabs_and_sfn_distribution_from_rows()
     {
-        FiscalYearCycle.TryParse("FY26", out var cycle).Should().BeTrue();
+        if (!FiscalYearCycle.TryParse("FY26", out var cycle))
+        {
+            throw new InvalidOperationException("FY26 should parse.");
+        }
+
         var rows = new[]
         {
             new ProjectListRowDto("CA-A-111-H", "1000001", "2025-1", "K1234", "Larkspur, S.", "ATM", "201", "Clean"),

--- a/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Server.Models;
+using Server.Models.ProjectList;
+using Server.ProjectList;
+
+namespace Server.Tests.ProjectList;
+
+public class ProjectListResponseFactoryTests
+{
+    [Fact]
+    public void Create_counts_tabs_and_sfn_distribution_from_rows()
+    {
+        FiscalYearCycle.TryParse("FY26", out var cycle).Should().BeTrue();
+        var rows = new[]
+        {
+            new ProjectListRowDto("CA-A-111-H", "1000001", "2025-1", "K1234", "Larkspur, S.", "ATM", "201", "Clean"),
+            new ProjectListRowDto("CA-B-222-CG", "1000002", "2025-2", null, "Okonkwo, Y.", "ANS", "204", "SFN mismatch"),
+            new ProjectListRowDto("CA-C-333-CG", "1000003", "2025-3", null, "Naidoo, T.", "VEN", "204", "No PGM match"),
+        };
+
+        var response = ProjectListResponseFactory.Create(cycle!, rows, 10, 20, 30, 40);
+
+        response.FiscalYear.Should().Be("FY26");
+        response.CycleStart.Should().Be(new DateOnly(2025, 10, 1));
+        response.CycleEnd.Should().Be(new DateOnly(2026, 9, 30));
+        response.Counts.Should().Be(new ProjectListCountsDto(2, 1, 3));
+        response.Summary.ActiveNifa.Should().Be(10);
+        response.Summary.AllNifa.Should().Be(20);
+        response.Summary.PgmRecords.Should().Be(30);
+        response.Summary.AlnCodes.Should().Be(40);
+        response.Summary.IssuesToResolve.Should().Be(2);
+        response.Summary.SfnDistribution.Should().Equal(
+            new SfnDistributionDto("201", 1),
+            new SfnDistributionDto("204", 2));
+        response.Rows.Should().Equal(rows);
+    }
+}

--- a/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
@@ -17,9 +17,39 @@ public class ProjectListResponseFactoryTests
 
         var rows = new[]
         {
-            new ProjectListRowDto("CA-A-111-H", "1000001", "2025-1", "K1234", "Larkspur, S.", "ATM", "201", "Clean"),
-            new ProjectListRowDto("CA-B-222-CG", "1000002", "2025-2", null, "Okonkwo, Y.", "ANS", "204", "SFN mismatch"),
-            new ProjectListRowDto("CA-C-333-CG", "1000003", "2025-3", null, "Naidoo, T.", "VEN", "204", "No PGM match"),
+            new ProjectListRowDto(
+                "CA-A-111-H",
+                "1000001",
+                "2025-1",
+                "K1234",
+                "Larkspur, S.",
+                "10000001",
+                "Larkspur, Sasha",
+                "ATM",
+                "201",
+                "Clean"),
+            new ProjectListRowDto(
+                "CA-B-222-CG",
+                "1000002",
+                "2025-2",
+                null,
+                "Okonkwo, Y.",
+                "10000002",
+                "Okonkwo, Yara",
+                "ANS",
+                "204",
+                "SFN mismatch"),
+            new ProjectListRowDto(
+                "CA-C-333-CG",
+                "1000003",
+                "2025-3",
+                null,
+                "Naidoo, T.",
+                "10000003",
+                "Naidoo, Talia",
+                "VEN",
+                "204",
+                "No PGM match"),
         };
 
         var response = ProjectListResponseFactory.Create(cycle, rows, 10, 20, 30, 40);

--- a/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListResponseFactoryTests.cs
@@ -18,7 +18,7 @@ public class ProjectListResponseFactoryTests
             new ProjectListRowDto("CA-C-333-CG", "1000003", "2025-3", null, "Naidoo, T.", "VEN", "204", "No PGM match"),
         };
 
-        var response = ProjectListResponseFactory.Create(cycle!, rows, 10, 20, 30, 40);
+        var response = ProjectListResponseFactory.Create(cycle, rows, 10, 20, 30, 40);
 
         response.FiscalYear.Should().Be("FY26");
         response.CycleStart.Should().Be(new DateOnly(2025, 10, 1));


### PR DESCRIPTION
This is branched from [swe/ProjectList](/ucdavis/AD419/tree/swe/ProjectList), which has yet to be merged to main. PR #38 should be completed first.

Adds the project identification setup workflow, including a guided checklist for fiscal period confirmation, flat file uploads, PGM master-data import, issue review, and future finalization.

Summary:
- Added persisted workflow run/checklist state with EF entities and migration.
- Added project identification API endpoints and service logic for setup state, checklist completion, stale import detection, and PGM import tracking.
- Integrated the checklist into the project identification stage and tied it to React Query.
- Reworked flat-file import UI pieces for reuse inside checklist steps.
- Updated project list rendering to use the selected fiscal period from setup state.
- Added server and client tests for workflow state, checklist behavior, import tracking, and route integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided Project Identification workflow with fiscal-period confirmation and expandable checklist steps, including flat-file upload (with validation feedback) and PGM import, plus step completion/review actions.
  * Added a Project List experience with fiscal-year filtering, Issues/Clean/All tabs, search, and improved summary/badge presentation.
* **Bug Fixes**
  * Improved project matching and cycle-date logic for more accurate status and issue counts.
  * Enhanced resilience with reliable “Retry” when the project list fails to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->