### PR TITLE
Expense import: database objects

### DIFF
--- a/database/data/Functions/ImportBlockingIssueForCycle.sql
+++ b/database/data/Functions/ImportBlockingIssueForCycle.sql
@@ -1,0 +1,19 @@
+CREATE FUNCTION [data].[ImportBlockingIssueForCycle]
+(
+    @CycleStart DATE,
+    @CycleEnd DATE
+)
+RETURNS NVARCHAR(200)
+AS
+BEGIN
+    -- The reason an expense import cannot run for the given cycle, or NULL
+    -- when it can. The one definition shared by the import trigger endpoint
+    -- (rejects the run upfront) and the BuildProjects guard (fails closed if
+    -- a run reaches it anyway), so the two can never drift.
+    RETURN CASE
+        WHEN NOT EXISTS (SELECT 1 FROM [data].[ActiveProjects])
+            THEN N'ActiveProjects is empty; complete Project Identification before building the project list.'
+        WHEN EXISTS (SELECT 1 FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd) WHERE [Status] <> 'Clean')
+            THEN N'Unresolved project issues exist; resolve them in Project Identification first.'
+    END;
+END

--- a/database/data/StoredProcedures/BuildProjects.sql
+++ b/database/data/StoredProcedures/BuildProjects.sql
@@ -21,13 +21,11 @@ BEGIN
     -- project list; downstream consumers (expense views, associations) read
     -- this table instead of re-deriving the joins.
 
-    IF NOT EXISTS (SELECT 1 FROM [data].[ActiveProjects])
-        THROW 50000, 'ActiveProjects is empty; complete Project Identification before building the project list.', 1;
-
-    -- Fail closed on the same definition the Project Identification UI shows:
-    -- any non-Clean project means identification is not finished.
-    IF EXISTS (SELECT 1 FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd) WHERE [Status] <> 'Clean')
-        THROW 50000, 'Unresolved project issues exist; resolve them in Project Identification first.', 1;
+    -- Fail closed on the shared readiness definition (also used by the import
+    -- trigger endpoint, which normally rejects a not-ready run before it starts).
+    DECLARE @blockingIssue NVARCHAR(200) = [data].[ImportBlockingIssueForCycle](@CycleStart, @CycleEnd);
+    IF @blockingIssue IS NOT NULL
+        THROW 50000, @blockingIssue, 1;
 
     BEGIN TRAN;
 
@@ -72,6 +70,10 @@ BEGIN
 
     COMMIT;
 
-    -- Row count for the import run stage.
-    SELECT COUNT(*) AS ProjectRowsBuilt FROM [data].[Projects];
+    -- Counts for the import run stage: rows are NIFA x AE project pairs (204
+    -- awards fan out to many AE projects), so both grains are reported.
+    SELECT
+        COUNT(*) AS AeProjects,
+        COUNT(DISTINCT [AccessionNumber]) AS NifaProjects
+    FROM [data].[Projects];
 END

--- a/database/data/StoredProcedures/ClassifyTransactions.sql
+++ b/database/data/StoredProcedures/ClassifyTransactions.sql
@@ -62,6 +62,22 @@ BEGIN
     LEFT JOIN [data].[ChartSegments] cs
         ON cs.[SegmentName] = 'Account' AND cs.[Code] = t.[Account];
 
+    -- AccountInUcPath, AE: accounts that also appear in the UCPath pull. Those
+    -- dollars are reported from payroll detail, so the AE rows are excluded to
+    -- avoid double counting (2025 deleted them; a flag keeps them reviewable).
+    UPDATE t
+    SET [AccountInUcPath] =
+        CASE
+            WHEN t.[Account] IS NULL THEN 0
+            WHEN EXISTS
+            (
+                SELECT 1 FROM [data].[UcPathTransactions] u
+                WHERE u.[Account] = t.[Account]
+            ) THEN 1
+            ELSE 0
+        END
+    FROM [data].[AETransactions] t;
+
     -- Row counts for the import run stage.
     SELECT
         (SELECT COUNT(*) FROM [data].[AETransactions])     AS AeRowsClassified,

--- a/database/data/StoredProcedures/SeedSegmentClassifications.sql
+++ b/database/data/StoredProcedures/SeedSegmentClassifications.sql
@@ -8,11 +8,13 @@ BEGIN
     -- Existing rows and their classifications are never modified: unclassified
     -- fails closed downstream until someone classifies the code in step 2.
     --
-    -- Descriptions come from the ChartSegments reference data where available.
-    -- ERN codes (UCPath earnings codes) have no local description source;
-    -- the UCPath import fills those in from the PeopleSoft earnings table.
-    -- 'XXX' is the placeholder ERN code on fringe rows, which carry no FTE, so
-    -- classifying it is meaningless and it is not seeded.
+    -- Descriptions come from the ChartSegments reference data where available;
+    -- ERN descriptions come from the imported UcPathTransactions rows, which
+    -- carry UC_EARNCD_DESCR from the salary view. Existing Ern rows with a
+    -- NULL description are backfilled the same way (a description is metadata,
+    -- not a classification). 'XXX' is the placeholder ERN code on fringe rows,
+    -- which carry no FTE, so classifying it is meaningless and it is not
+    -- seeded.
 
     DECLARE @inserted TABLE ([SegmentType] NVARCHAR(20) NOT NULL);
 
@@ -45,10 +47,18 @@ BEGIN
     SELECT
         tv.SegmentType,
         tv.Code,
-        LEFT(cs.[Description], 300)
+        LEFT(COALESCE(cs.[Description], ern.[Description]), 300)
     FROM TransactionValues tv
     LEFT JOIN [data].[ChartSegments] cs
         ON cs.[SegmentName] = tv.SegmentType AND cs.[Code] = tv.Code
+    LEFT JOIN
+    (
+        SELECT [ErnCode], MAX([ErnDescription]) AS [Description]
+        FROM [data].[UcPathTransactions]
+        WHERE [ErnDescription] IS NOT NULL
+        GROUP BY [ErnCode]
+    ) ern
+        ON tv.SegmentType = 'Ern' AND ern.[ErnCode] = tv.Code
     WHERE NOT EXISTS
     (
         SELECT 1
@@ -56,6 +66,22 @@ BEGIN
         WHERE existing.[SegmentType] = tv.SegmentType
           AND existing.[Code] = tv.Code
     );
+
+    -- Backfill descriptions on Ern rows seeded before their description was
+    -- available (for example a code first seen on rows imported after the
+    -- code itself was seeded).
+    UPDATE sc
+    SET sc.[Description] = LEFT(ern.[Description], 300)
+    FROM [data].[SegmentClassifications] sc
+    JOIN
+    (
+        SELECT [ErnCode], MAX([ErnDescription]) AS [Description]
+        FROM [data].[UcPathTransactions]
+        WHERE [ErnDescription] IS NOT NULL
+        GROUP BY [ErnCode]
+    ) ern
+        ON ern.[ErnCode] = sc.[Code]
+    WHERE sc.[SegmentType] = 'Ern' AND sc.[Description] IS NULL;
 
     -- One row per segment type with the number of newly seeded codes
     -- (types with nothing new are omitted).

--- a/database/data/Tables/AETransactions.sql
+++ b/database/data/Tables/AETransactions.sql
@@ -43,6 +43,7 @@ CREATE TABLE [data].[AETransactions]
     -- Persisted exclusions for rules not owned by step 2 classification.
     -- NULL = not yet classified (fails closed downstream).
     [ExcludedByDate]                 BIT            NULL,
+    [AccountInUcPath]                BIT            NULL,  -- account also appears in UCPath data (dollars come from payroll detail instead)
 
     [LoadedAt]                       DATETIME2(3)   NULL CONSTRAINT [DF_AETransactions_LoadedAt] DEFAULT (SYSUTCDATETIME()),
     CONSTRAINT [PK_AETransactions] PRIMARY KEY CLUSTERED ([Id])

--- a/database/data/Tables/Projects.sql
+++ b/database/data/Tables/Projects.sql
@@ -14,9 +14,11 @@ CREATE TABLE [data].[Projects]
     [Is204]                       BIT           NOT NULL,
     [Sfn]                         NVARCHAR(7)   NOT NULL, -- from project number suffix: 201 | 202 | 204 | 205 | UNKNOWN
 
-    -- AE side (from PGMProjects via award number match). Null when a non-204
-    -- project has no PGM master data match; NIFA/PGM SFN agreement is checked
-    -- during Project Identification.
+    -- AE side (from PGMProjects via award number match). Null when the project
+    -- has no PGM master data match, which is the norm for non-204 projects
+    -- (Hatch and animal health are state funded with no AE project). The
+    -- Project Identification guard requires a match, and therefore a value,
+    -- for every 204 row; only the 204 rows feed the import carve-out lists.
     [AEProjectNumber]             NVARCHAR(50)  NULL,
     [SponsorAwardNumber]          NVARCHAR(100) NULL,
     [PrincipalInvestigatorNames]  NVARCHAR(MAX) NULL,

--- a/database/data/Tables/UcPathTransactions.sql
+++ b/database/data/Tables/UcPathTransactions.sql
@@ -23,6 +23,7 @@ CREATE TABLE [data].[UcPathTransactions]
     [FinanceDocTypeCd]       NVARCHAR(4)    NULL,
     -- Components of the natural key are required.
     [ErnCode]                NVARCHAR(3)    NOT NULL,   -- ERNCD for salary rows, 'XXX' for fringe rows (source ERNCD is blank on most fringe)
+    [ErnDescription]         NVARCHAR(120)  NULL,       -- UC_EARNCD_DESCR from the salary view; NULL on fringe rows. Feeds the Ern seed in SegmentClassifications
     [EmployeeId]             NVARCHAR(10)   NOT NULL,
     [EmployeeName]           NVARCHAR(100)  NULL,
     [PositionNumber]         NVARCHAR(8)    NOT NULL,   -- rare source rows without one are excluded at import

--- a/database/data/Views/v_BcbsDepartments.sql
+++ b/database/data/Views/v_BcbsDepartments.sql
@@ -1,0 +1,10 @@
+CREATE VIEW [data].[v_BcbsDepartments]
+AS
+-- Financial department codes under the BCBS00C parent department, a level C
+-- node (ParentLevel2Code) per the code suffix convention. BCBS expenses are
+-- only reportable on fund 13U02 (or via a 204 project), so the AE import
+-- limits its BCBS arm to these codes.
+SELECT [Code]
+FROM [data].[ChartSegments]
+WHERE [SegmentName] = 'FinancialDepartment'
+  AND [ParentLevel2Code] = 'BCBS00C';

--- a/database/data/Views/v_CaesAnrDepartments.sql
+++ b/database/data/Views/v_CaesAnrDepartments.sql
@@ -1,0 +1,11 @@
+CREATE VIEW [data].[v_CaesAnrDepartments]
+AS
+-- Financial department codes under the CAES (AAES00C) or ANR (9AAES0D)
+-- parent departments. The parents sit at fixed hierarchy levels, per the code
+-- suffix convention: AAES00C is a level C node (ParentLevel2Code) and 9AAES0D
+-- is level D (ParentLevel3Code). Drives the AE transaction import's wide net
+-- and is reusable by the expense display views.
+SELECT [Code]
+FROM [data].[ChartSegments]
+WHERE [SegmentName] = 'FinancialDepartment'
+  AND ([ParentLevel2Code] = 'AAES00C' OR [ParentLevel3Code] = '9AAES0D');

--- a/tests/server.tests/ProjectList/ProjectListSqlTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListSqlTests.cs
@@ -79,7 +79,8 @@ public class ProjectListSqlTests
 
         sql.Should().Contain("@CycleStart DATE");
         sql.Should().Contain("@CycleEnd DATE");
-        sql.Should().Contain("FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd)");
+        // the non-Clean check lives in the shared readiness function
+        sql.Should().Contain("[data].[ImportBlockingIssueForCycle](@CycleStart, @CycleEnd)");
         sql.Should().Contain("FROM [data].[NifaProjectsForCycle](@CycleStart, @CycleEnd) nv");
         sql.Should().NotContain("[data].[v_ProjectList]");
         sql.Should().NotContain("[data].[v_NifaProjects]");


### PR DESCRIPTION
Part 1 of 4 splitting #45 (expense data import pipeline, #31) into reviewable pieces: #49 database, #52 run/stage infrastructure, #50 pipeline, #51 UI. Now stacked on #48 (project issue resolution) and rebuilt on its cycle-parameterized functions: the ReportingCycle snapshot and v_NifaProjects changes from earlier revisions are gone, and the shared readiness definition is the cycle-parameterized ImportBlockingIssueForCycle function. Retarget to main after #48 merges. Database layer only; safe to deploy ahead of the backend.

- ImportBlockingIssueForCycle(@CycleStart, @CycleEnd): the single readiness definition (ActiveProjects populated, no non-Clean ProjectListForCycle rows) shared by the BuildProjects guard and the import trigger endpoint so they cannot drift.

- v_CaesAnrDepartments / v_BcbsDepartments: the import carve-out department lists at their fixed parent levels (AAES00C and BCBS00C at level C, 9AAES0D at level D; verified set-identical to a full six-level scan against imported segment data). Reusable by the Expense Review display views (#32).
- BuildProjects: fails closed on the shared function and returns both grains (AE project pairs and distinct NIFA projects) for the progress UI.
- Projects comment documents why AEProjectNumber is null for non-204 projects (Hatch, animal health have no PGM master data match by design).
- AETransactions: AccountInUcPath column and ExcludedByDate stamping via the extended ClassifyTransactions.

Also adds the ErnDescription column on UcPathTransactions so the seed sproc fills Ern descriptions from imported rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confirmed reporting-cycle tracking for consistent fiscal-year and date calculations.
  - Added department classifications for BCBS, CAES, and ANR reporting.
  - Added account matching indicators to identify accounts present in UCPath data.

- **Improvements**
  - Improved project rebuild readiness checks and completion reporting.
  - Improved expense-import blocking messages by clearly identifying unresolved prerequisites.
  - Updated project matching guidance and reporting-cycle fallback behavior for more reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->