### PR TITLE
Expense import: pipeline services and endpoints

### DIFF
--- a/server.core/Data/DataDbConnection.cs
+++ b/server.core/Data/DataDbConnection.cs
@@ -6,7 +6,9 @@ public static class DataDbConnection
 {
     public const string EnvironmentVariableName = "DATA_DB_CONNECTION";
     public const string ConnectionStringName = "DataConnection";
-    public const int ImportCommandTimeoutSeconds = 600;
+    // The AE pull streams ~465k rows through the linked server's row-by-row ODBC
+    // fetch, which takes over 10 minutes on its own; 600s timed out in practice.
+    public const int ImportCommandTimeoutSeconds = 3600;
 
     public static string Resolve(IConfiguration configuration, string? fallbackConnectionString)
     {

--- a/server.core/Data/DatamartConnection.cs
+++ b/server.core/Data/DatamartConnection.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Server.Core.Data;
+
+public static class DatamartConnection
+{
+    public const string EnvironmentVariableName = "DATAMART_CONNECTION";
+    public const string ConnectionStringName = "Datamart";
+
+    public static string Resolve(IConfiguration configuration)
+    {
+        var environmentValue = configuration[EnvironmentVariableName];
+        var connectionString = string.IsNullOrWhiteSpace(environmentValue)
+            ? configuration.GetConnectionString(ConnectionStringName)
+            : environmentValue;
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"No datamart connection string configured. Set the {EnvironmentVariableName} environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        return connectionString;
+    }
+}

--- a/server.core/Import/AeTransactionsImportService.cs
+++ b/server.core/Import/AeTransactionsImportService.cs
@@ -1,0 +1,206 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class AeTransactionsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string RemoteLinkedServer = "AE_Redshift_PROD";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[AETransactions]";
+
+    // source reader column -> destination table column. Id, ExcludedByDate, AccountInUcPath, LoadedAt are absent on
+    // purpose: the destination defaults apply to unmapped columns.
+    // Source names verified against the warehouse 2026-07-30; the table's two other
+    // columns (actual_flag, encumbrance_type_code) are filter-only and not pulled.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("entity", "Entity"),
+        ("fund", "Fund"),
+        ("financial_department", "FinancialDepartment"),
+        ("account", "Account"),
+        ("purpose", "Purpose"),
+        ("program", "Program"),
+        ("project", "Project"),
+        ("activity", "Activity"),
+        ("entity_description", "EntityDescription"),
+        ("fund_description", "FundDescription"),
+        ("financial_department_description", "FinancialDepartmentDescription"),
+        ("account_description", "AccountDescription"),
+        ("purpose_description", "PurposeDescription"),
+        ("program_description", "ProgramDescription"),
+        ("project_description", "ProjectDescription"),
+        ("activity_description", "ActivityDescription"),
+        ("document_type", "DocumentType"),
+        ("accounting_sequence_number", "AccountingSequenceNumber"),
+        ("tracking_no", "TrackingNo"),
+        ("reference", "Reference"),
+        ("journal_line_description", "JournalLineDescription"),
+        ("journal_acct_date", "JournalAcctDate"),
+        ("journal_name", "JournalName"),
+        ("journal_reference", "JournalReference"),
+        ("period_name", "PeriodName"),
+        ("journal_batch_name", "JournalBatchName"),
+        ("journal_source", "JournalSource"),
+        ("journal_category", "JournalCategory"),
+        ("batch_status", "BatchStatus"),
+        ("actual_amount", "Amount"),
+        ("commitment_amount", "CommitmentAmount"),
+        ("obligation_amount", "ObligationAmount"),
+        ("etl_load_dt", "EtlLoadDt"),
+    ];
+
+    // The department lists are DACPAC views so the display views built in the
+    // Expense Review work can share them.
+    private const string CaesAnrDepartmentsSql = "SELECT [Code] FROM [data].[v_CaesAnrDepartments]";
+    private const string BcbsDepartmentsSql = "SELECT [Code] FROM [data].[v_BcbsDepartments]";
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AeTransactionsImportService> _logger;
+
+    public AeTransactionsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<AeTransactionsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
+    {
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+
+        var caesAnrDepartments = await ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
+        var bcbsDepartments = await ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
+        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+
+        var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
+        var periods = ImportSql.PeriodNames(windowStart, windowEnd);
+
+        var remoteQuery = BuildRemoteQuery(periods, caesAnrDepartments, bcbsDepartments, projects204);
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var query = new SqlCommand($"EXEC (@remoteQuery) AT [{RemoteLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1)
+        {
+            Value = remoteQuery,
+        });
+
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable};", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        var rowsImported = (int)bulkCopy.RowsCopied64;
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation("Imported {RowCount} AE transactions", rowsImported);
+        return rowsImported;
+    }
+
+    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    public static string BuildRemoteQuery(
+        IReadOnlyList<string> periodNames,
+        IReadOnlyList<string> caesAnrDepartments,
+        IReadOnlyList<string> bcbsDepartments,
+        IReadOnlyList<string> projects204)
+    {
+        if (caesAnrDepartments.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "CAES/ANR department list is empty; run the ChartSegments reference import first.");
+        }
+
+        // The wide net: departments under CAES/ANR, plus any 204-mapped project, plus
+        // BCBS departments only on fund 13U02 (204 BCBS rows come in via the project arm).
+        // No purpose, account, fund, or activity filters here; those are visible
+        // exclusion reasons applied downstream.
+        var arms = new List<string>
+        {
+            $"financial_department IN ({ImportSql.QuoteList(caesAnrDepartments)})",
+        };
+
+        if (projects204.Count > 0)
+        {
+            arms.Add($"project IN ({ImportSql.QuoteList(projects204)})");
+        }
+
+        if (bcbsDepartments.Count > 0)
+        {
+            arms.Add($"(financial_department IN ({ImportSql.QuoteList(bcbsDepartments)}) AND fund = '13U02')");
+        }
+
+        return $"""
+            SELECT entity, fund, financial_department, account, purpose, program, project, activity,
+                entity_description, fund_description, financial_department_description, account_description,
+                purpose_description, program_description, project_description, activity_description,
+                document_type, accounting_sequence_number, tracking_no, reference, journal_line_description,
+                journal_acct_date, journal_name, journal_reference, period_name, journal_batch_name,
+                journal_source, journal_category, batch_status,
+                actual_amount, commitment_amount, obligation_amount, etl_load_dt
+            FROM ae_dwh.transactional_listing_report
+            WHERE actual_flag = 'A'
+              AND period_name IN ({ImportSql.QuoteList(periodNames)})
+              AND ({string.Join("\n               OR ", arms)})
+            """;
+    }
+}

--- a/server.core/Import/AeTransactionsImportService.cs
+++ b/server.core/Import/AeTransactionsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class AeTransactionsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -77,15 +76,7 @@ public sealed class AeTransactionsImportService
 
     public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());
@@ -93,9 +84,9 @@ public sealed class AeTransactionsImportService
         await using var destination = new SqlConnection(destinationConnectionString);
         await destination.OpenAsync(cancellationToken);
 
-        var caesAnrDepartments = await ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
-        var bcbsDepartments = await ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
-        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var caesAnrDepartments = await ImportSql.ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
+        var bcbsDepartments = await ImportSql.ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
+        var projects204 = await ImportSql.ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
 
         var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
         var periods = ImportSql.PeriodNames(windowStart, windowEnd);
@@ -143,19 +134,6 @@ public sealed class AeTransactionsImportService
 
         _logger.LogInformation("Imported {RowCount} AE transactions", rowsImported);
         return rowsImported;
-    }
-
-    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
-    {
-        var values = new List<string>();
-        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
-        await using var reader = await command.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            values.Add(reader.GetString(0));
-        }
-
-        return values;
     }
 
     public static string BuildRemoteQuery(

--- a/server.core/Import/ChartSegmentsImportService.cs
+++ b/server.core/Import/ChartSegmentsImportService.cs
@@ -1,0 +1,156 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class ChartSegmentsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string RemoteLinkedServer = "AE_Redshift_PROD";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[ChartSegments]";
+
+    public static readonly (string SegmentName, string SourceTable)[] Segments =
+    [
+        ("Entity", "ae_dwh.erp_entity"),
+        ("Fund", "ae_dwh.erp_fund"),
+        ("FinancialDepartment", "ae_dwh.erp_fin_dept"),
+        ("Account", "ae_dwh.erp_account"),
+        ("Purpose", "ae_dwh.erp_purpose"),
+        ("Program", "ae_dwh.erp_program"),
+        ("Project", "ae_dwh.erp_project"),
+        ("Activity", "ae_dwh.erp_activity"),
+    ];
+
+    // source reader column -> destination table column. LoadedAt is absent on
+    // purpose: the destination default applies to unmapped columns.
+    // Source names verified against the warehouse 2026-07-30; all eight erp_*
+    // tables share this schema.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("segment_name", "SegmentName"),
+        ("code", "Code"),
+        ("value_id", "ValueId"),
+        ("description", "Description"),
+        ("value_desc", "ValueDesc"),
+        ("hierarchy_depth", "HierarchyDepth"),
+        ("summary_flag", "SummaryFlag"),
+        ("enabled_flag", "EnabledFlag"),
+        ("start_date_active", "StartDateActive"),
+        ("end_date_active", "EndDateActive"),
+        ("parent_level_0_code", "ParentLevel0Code"),
+        ("parent_level_1_code", "ParentLevel1Code"),
+        ("parent_level_2_code", "ParentLevel2Code"),
+        ("parent_level_3_code", "ParentLevel3Code"),
+        ("parent_level_4_code", "ParentLevel4Code"),
+        ("parent_level_5_code", "ParentLevel5Code"),
+    ];
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ChartSegmentsImportService> _logger;
+
+    public ChartSegmentsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<ChartSegmentsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportSegmentAsync(string segmentName, CancellationToken cancellationToken = default)
+    {
+        var (_, sourceTable) = Segments.Single(s => s.SegmentName == segmentName);
+
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var query = new SqlCommand($"EXEC (@remoteQuery) AT [{RemoteLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1)
+        {
+            Value = BuildRemoteQuery(segmentName, sourceTable),
+        });
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable} WHERE [SegmentName] = @segmentName;", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            delete.Parameters.Add(new SqlParameter("@segmentName", SqlDbType.NVarChar, 30) { Value = segmentName });
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        var rowsImported = (int)bulkCopy.RowsCopied64;
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation("Imported {RowCount} {Segment} chart segments", rowsImported, segmentName);
+        return rowsImported;
+    }
+
+    /// <summary>
+    /// Builds the Redshift query run on the warehouse via the pass-through. The segment_name
+    /// is cast to a narrow VARCHAR(30) so MSDASQL binds it inline rather than as a streamed LOB.
+    /// The Redshift ODBC driver reports wide/untyped VARCHAR as SQL_LONGVARCHAR (streamed), which
+    /// EXEC ... AT cannot stream, failing with error 7341. Explicit narrow types force inline binding.
+    ///
+    /// Column names verified against the warehouse 2026-07-30.
+    /// </summary>
+    public static string BuildRemoteQuery(string segmentName, string sourceTable)
+    {
+        if (!Segments.Any(s => s.SegmentName == segmentName))
+        {
+            throw new ArgumentException($"Unknown segment name '{segmentName}'.", nameof(segmentName));
+        }
+
+        return $"""
+            SELECT CAST('{segmentName}' AS VARCHAR(30)) AS segment_name,
+                code, value_id, description, value_desc, hierarchy_depth,
+                summary_flag, enabled_flag, start_date_active, end_date_active,
+                parent_level_0_code, parent_level_1_code, parent_level_2_code,
+                parent_level_3_code, parent_level_4_code, parent_level_5_code
+            FROM {sourceTable}
+            WHERE code IS NOT NULL
+            """;
+    }
+}

--- a/server.core/Import/ChartSegmentsImportService.cs
+++ b/server.core/Import/ChartSegmentsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class ChartSegmentsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -69,15 +68,7 @@ public sealed class ChartSegmentsImportService
     {
         var (_, sourceTable) = Segments.Single(s => s.SegmentName == segmentName);
 
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());

--- a/server.core/Import/ImportReadinessCheck.cs
+++ b/server.core/Import/ImportReadinessCheck.cs
@@ -1,0 +1,51 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public interface IImportReadinessCheck
+{
+    /// <summary>
+    /// Returns the reason an import run cannot start for the given cycle, or
+    /// null when it can. Reads [data].[ImportBlockingIssueForCycle], the same
+    /// definition the BuildProjects guard uses, so a not-ready run is rejected
+    /// at the trigger instead of failing at the build projects stage mid-run.
+    /// </summary>
+    Task<string?> GetBlockingIssueAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken);
+}
+
+public sealed class ImportReadinessCheck : IImportReadinessCheck
+{
+    private const string CheckSql =
+        "SELECT [data].[ImportBlockingIssueForCycle](@cycleStart, @cycleEnd)";
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+
+    public ImportReadinessCheck(DataDbContext dataDbContext, IConfiguration configuration)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+    }
+
+    public async Task<string?> GetBlockingIssueAsync(
+        DateOnly cycleStart,
+        DateOnly cycleEnd,
+        CancellationToken cancellationToken)
+    {
+        var connectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = new SqlCommand(CheckSql, connection);
+        command.Parameters.Add(new SqlParameter("@cycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@cycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is DBNull or null ? null : (string)result;
+    }
+}

--- a/server.core/Import/ImportSql.cs
+++ b/server.core/Import/ImportSql.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using Microsoft.Data.SqlClient;
+using Server.Core.Data;
 
 namespace Server.Core.Import;
 
@@ -35,4 +37,20 @@ public static class ImportSql
 
     public static (DateOnly Start, DateOnly End) BufferedWindow(DateOnly cycleStart, DateOnly cycleEnd) =>
         (cycleStart.AddMonths(-3), cycleEnd.AddMonths(3));
+
+    public static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection)
+        {
+            CommandTimeout = DataDbConnection.ImportCommandTimeoutSeconds,
+        };
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
 }

--- a/server.core/Import/ImportSql.cs
+++ b/server.core/Import/ImportSql.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace Server.Core.Import;
+
+public static class ImportSql
+{
+    // The 204 carve-out list shared by the AE and UCPath imports. Every 204 row
+    // has an AEProjectNumber by the readiness guard; the null filter is defense
+    // in depth.
+    public const string Projects204Sql = """
+        SELECT DISTINCT [AEProjectNumber] FROM [data].[Projects]
+        WHERE [Sfn] = '204' AND [AEProjectNumber] IS NOT NULL
+        """;
+
+    // Period names must match how ClassifyTransactions generates its cycle set
+    // (FORMAT(@month, 'MMM-yy', 'en-US')) so pull and stamp agree.
+    public static List<string> PeriodNames(DateOnly start, DateOnly end)
+    {
+        var names = new List<string>();
+        var month = new DateOnly(start.Year, start.Month, 1);
+        while (month <= end)
+        {
+            names.Add(month.ToString("MMM-yy", CultureInfo.GetCultureInfo("en-US")));
+            month = month.AddMonths(1);
+        }
+
+        return names;
+    }
+
+    public static string QuoteList(IEnumerable<string> values) =>
+        string.Join(",", values.Select(v => $"'{v.Replace("'", "''")}'"));
+
+    public static int HoursInFederalFiscalYear(int federalFiscalYear) =>
+        federalFiscalYear % 4 == 0 ? 2096 : 2088;
+
+    public static (DateOnly Start, DateOnly End) BufferedWindow(DateOnly cycleStart, DateOnly cycleEnd) =>
+        (cycleStart.AddMonths(-3), cycleEnd.AddMonths(3));
+}

--- a/server.core/Import/ImportStageProvider.cs
+++ b/server.core/Import/ImportStageProvider.cs
@@ -1,0 +1,52 @@
+namespace Server.Core.Import;
+
+public sealed class ImportStageProvider : IImportStageProvider
+{
+    private readonly ChartSegmentsImportService _chartSegments;
+    private readonly AeTransactionsImportService _aeTransactions;
+    private readonly UcPathTransactionsImportService _ucPathTransactions;
+    private readonly SprocStageService _sprocs;
+
+    public ImportStageProvider(
+        ChartSegmentsImportService chartSegments,
+        AeTransactionsImportService aeTransactions,
+        UcPathTransactionsImportService ucPathTransactions,
+        SprocStageService sprocs)
+    {
+        _chartSegments = chartSegments;
+        _aeTransactions = aeTransactions;
+        _ucPathTransactions = ucPathTransactions;
+        _sprocs = sprocs;
+    }
+
+    public IReadOnlyList<string> StageNames => ImportStageNames.All;
+
+    public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context)
+    {
+        var stages = new List<ImportStage>();
+
+        // Stage display names split FinancialDepartment into words; the service
+        // keys stay the stored SegmentName form.
+        var displayNames = new Dictionary<string, string> { ["FinancialDepartment"] = "Financial Department" };
+        foreach (var (segmentName, _) in ChartSegmentsImportService.Segments)
+        {
+            var display = displayNames.GetValueOrDefault(segmentName, segmentName);
+            stages.Add(ImportStage.FromRowCount(
+                ImportStageNames.ChartSegmentsPrefix + display,
+                ct => _chartSegments.ImportSegmentAsync(segmentName, ct)));
+        }
+
+        stages.Add(new ImportStage(ImportStageNames.BuildProjects,
+            ct => _sprocs.BuildProjectsAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.AeTransactions,
+            ct => _aeTransactions.ImportAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.UcPathTransactions,
+            ct => _ucPathTransactions.ImportAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.SeedSegmentClassifications,
+            ct => _sprocs.SeedSegmentClassificationsAsync(ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.ClassifyTransactions,
+            ct => _sprocs.ClassifyTransactionsAsync(context.CycleStart, context.CycleEnd, ct)));
+
+        return stages;
+    }
+}

--- a/server.core/Import/PgmProjectsImportService.cs
+++ b/server.core/Import/PgmProjectsImportService.cs
@@ -9,8 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class PgmProjectsImportService : IPgmProjectsImportService
 {
-    public const string ConnectionStringName = "Datamart";
-
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -93,16 +91,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
 
     public async Task<PgmProjectsImportResult> ImportAsync(DateOnly reportDate, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());

--- a/server.core/Import/SprocStageService.cs
+++ b/server.core/Import/SprocStageService.cs
@@ -1,0 +1,98 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class SprocStageService
+{
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+
+    public SprocStageService(DataDbContext dataDbContext, IConfiguration configuration)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+    }
+
+    public async Task<ImportStageResult> BuildProjectsAsync(
+        DateOnly cycleStart,
+        DateOnly cycleEnd,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[BuildProjects]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        command.Parameters.Add(new SqlParameter("@CycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@CycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return new ImportStageResult(0);
+        }
+
+        var aeProjects = reader.GetInt32(reader.GetOrdinal("AeProjects"));
+        var nifaProjects = reader.GetInt32(reader.GetOrdinal("NifaProjects"));
+        return new ImportStageResult(
+            aeProjects,
+            $"{aeProjects:N0} AE projects, {nifaProjects:N0} NIFA projects");
+    }
+
+    public async Task<int> SeedSegmentClassificationsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[SeedSegmentClassifications]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+
+        var total = 0;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        var insertedCountOrdinal = reader.GetOrdinal("InsertedCount");
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            total += reader.GetInt32(insertedCountOrdinal);
+        }
+
+        return total;
+    }
+
+    public async Task<int> ClassifyTransactionsAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[ClassifyTransactions]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        command.Parameters.Add(new SqlParameter("@cycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@cycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return 0;
+        }
+
+        var aeRowsClassified = reader.GetInt32(reader.GetOrdinal("AeRowsClassified"));
+        var ucPathRowsClassified = reader.GetInt32(reader.GetOrdinal("UcPathRowsClassified"));
+        return aeRowsClassified + ucPathRowsClassified;
+    }
+
+    private async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connectionString = DataDbConnection.Resolve(_configuration, _dataDbContext.Database.GetConnectionString());
+        var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+}

--- a/server.core/Import/UcPathTransactionsImportService.cs
+++ b/server.core/Import/UcPathTransactionsImportService.cs
@@ -1,0 +1,375 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class UcPathTransactionsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string HcmLinkedServer = "AIT_BISTG_PRD-CAES_HCMODS_APPUSER";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[UcPathTransactions]";
+
+    // source reader column -> destination table column. EmployeeName, ExcludedByDate, AccountNotInAE, LoadedAt are absent on
+    // purpose: the destination defaults apply to unmapped columns. FinanceDocTypeCd and
+    // RateTypeCd are also unmapped: neither column exists on the labor views
+    // (verified against the warehouse 2026-07-30), so they stay NULL.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("labor_transaction_id", "LaborTransactionId"),
+        ("entity", "Entity"),
+        ("fund", "Fund"),
+        ("financial_department", "FinancialDepartment"),
+        ("parent_department", "ParentDepartment"),
+        ("account", "Account"),
+        ("purpose", "Purpose"),
+        ("program", "Program"),
+        ("project", "Project"),
+        ("activity", "Activity"),
+        ("erncd", "ErnCode"),
+        ("ern_description", "ErnDescription"),
+        ("employee_id", "EmployeeId"),
+        ("position_number", "PositionNumber"),
+        ("eff_dt", "EffDt"),
+        ("job_code", "JobCode"),
+        ("hours", "Hours"),
+        ("amount", "Amount"),
+        ("pay_rate", "PayRate"),
+        ("calculated_fte", "CalculatedFte"),
+        ("pay_period_end_date", "PayPeriodEndDate"),
+        ("fringe_benefit_salary_cd", "FringeBenefitSalaryCd"),
+        ("paid_percent", "PaidPercent"),
+        ("ern_derived_percent", "ErnDerivedPercent"),
+        ("fiscal_year", "FiscalYear"),
+        ("period", "Period"),
+        ("emp_rcd", "EmpRcd"),
+        ("eff_seq", "EffSeq"),
+    ];
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<UcPathTransactionsImportService> _logger;
+
+    public UcPathTransactionsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<UcPathTransactionsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
+    {
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+
+        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
+        var fteDenominatorHours = ImportSql.HoursInFederalFiscalYear(cycleEnd.Year);
+
+        var salarySql = BuildSalaryQuery(projects204, fteDenominatorHours);
+        var fringSql = BuildFringeQuery(projects204);
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var salaryQuery = new SqlCommand(
+            $"EXEC (@remoteQuery, @windowStart, @windowEnd) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        salaryQuery.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = salarySql });
+        salaryQuery.Parameters.Add(new SqlParameter("@windowStart", SqlDbType.Date) { Value = windowStart });
+        salaryQuery.Parameters.Add(new SqlParameter("@windowEnd", SqlDbType.Date) { Value = windowEnd });
+
+        await using var fringeQuery = new SqlCommand(
+            $"EXEC (@remoteQuery, @windowStart, @windowEnd) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        fringeQuery.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = fringSql });
+        fringeQuery.Parameters.Add(new SqlParameter("@windowStart", SqlDbType.Date) { Value = windowStart });
+        fringeQuery.Parameters.Add(new SqlParameter("@windowEnd", SqlDbType.Date) { Value = windowEnd });
+
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable};", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        var totalRowsCopied =
+            await BulkCopyAsync(salaryQuery, destination, transaction, cancellationToken)
+            + await BulkCopyAsync(fringeQuery, destination, transaction, cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+
+        var rowsImported = (int)totalRowsCopied;
+        _logger.LogInformation("Imported {RowCount} UCPath transactions", rowsImported);
+
+        await EnrichEmployeeNamesAsync(source, destination, cancellationToken);
+        await EnrichJobCodesAsync(source, destination, windowEnd, cancellationToken);
+
+        return rowsImported;
+    }
+
+    private static async Task<long> BulkCopyAsync(
+        SqlCommand query,
+        SqlConnection destination,
+        SqlTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        return bulkCopy.RowsCopied64;
+    }
+
+    private async Task EnrichEmployeeNamesAsync(SqlConnection source, SqlConnection destination, CancellationToken ct)
+    {
+        await using (var create = new SqlCommand(
+            "CREATE TABLE #EmployeeNames ([EmployeeId] NVARCHAR(10) NOT NULL, [EmployeeName] NVARCHAR(100) NULL);",
+            destination))
+        {
+            await create.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var query = new SqlCommand($"EXEC (@remoteQuery) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildNamesQuery() });
+            using var bulkCopy = new SqlBulkCopy(destination) { DestinationTableName = "#EmployeeNames", BulkCopyTimeout = CommandTimeoutSeconds };
+            bulkCopy.ColumnMappings.Add("employee_id", "EmployeeId");
+            bulkCopy.ColumnMappings.Add("employee_name", "EmployeeName");
+            await using var reader = await query.ExecuteReaderAsync(ct);
+            await bulkCopy.WriteToServerAsync(reader, ct);
+        }
+
+        await using (var update = new SqlCommand(
+            """
+            -- UCD_PS_NAMES_V verified one row per EMPLID (2026-07-30: 27,275 rows, 27,275
+            -- distinct EMPLIDs); MAX() keeps the update deterministic if that ever changes
+            UPDATE t SET [EmployeeName] = LEFT(n.[EmployeeName], 100)
+            FROM [data].[UcPathTransactions] t
+            JOIN (SELECT [EmployeeId], MAX([EmployeeName]) AS [EmployeeName] FROM #EmployeeNames GROUP BY [EmployeeId]) n
+                ON n.[EmployeeId] = t.[EmployeeId];
+            DROP TABLE #EmployeeNames;
+            """, destination)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            await update.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private async Task EnrichJobCodesAsync(SqlConnection source, SqlConnection destination, DateOnly effDtCeiling, CancellationToken ct)
+    {
+        await using (var create = new SqlCommand(
+            "CREATE TABLE #PeopleSoftJobs ([EmployeeId] NVARCHAR(10), [EmpRcd] SMALLINT, [EffDt] DATETIME2(7), [EffSeq] SMALLINT, [PositionNumber] NVARCHAR(8), [TitleCode] NVARCHAR(4));",
+            destination))
+        {
+            await create.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var query = new SqlCommand($"EXEC (@remoteQuery, @effDtCeiling) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildJobCodeQuery() });
+            query.Parameters.Add(new SqlParameter("@effDtCeiling", SqlDbType.Date) { Value = effDtCeiling });
+            using var bulkCopy = new SqlBulkCopy(destination) { DestinationTableName = "#PeopleSoftJobs", BulkCopyTimeout = CommandTimeoutSeconds };
+            bulkCopy.ColumnMappings.Add("employee_id", "EmployeeId");
+            bulkCopy.ColumnMappings.Add("emp_rcd", "EmpRcd");
+            bulkCopy.ColumnMappings.Add("eff_dt", "EffDt");
+            bulkCopy.ColumnMappings.Add("eff_seq", "EffSeq");
+            bulkCopy.ColumnMappings.Add("position_number", "PositionNumber");
+            bulkCopy.ColumnMappings.Add("title_code", "TitleCode");
+            await using var reader = await query.ExecuteReaderAsync(ct);
+            await bulkCopy.WriteToServerAsync(reader, ct);
+        }
+
+        await using (var update = new SqlCommand(
+            """
+            WITH Ranked AS (
+                SELECT *,
+                    ROW_NUMBER() OVER (PARTITION BY [EmployeeId], [EmpRcd], [EffDt] ORDER BY [EffSeq] DESC) AS DateRank,
+                    ROW_NUMBER() OVER (PARTITION BY [EmployeeId], [EmpRcd], [PositionNumber] ORDER BY [EffDt] DESC, [EffSeq] DESC) AS PositionRank
+                FROM #PeopleSoftJobs
+            )
+            UPDATE t
+            SET [JobCode] = COALESCE(exactMatch.[TitleCode], positionMatch.[TitleCode])
+            FROM [data].[UcPathTransactions] t
+            LEFT JOIN (SELECT * FROM Ranked WHERE DateRank = 1) exactMatch
+                ON exactMatch.[EmployeeId] = t.[EmployeeId] AND exactMatch.[EmpRcd] = t.[EmpRcd]
+               AND exactMatch.[EffDt] = t.[EffDt] AND exactMatch.[EffSeq] = t.[EffSeq]
+            LEFT JOIN (SELECT * FROM Ranked WHERE PositionRank = 1) positionMatch
+                ON positionMatch.[EmployeeId] = t.[EmployeeId] AND positionMatch.[EmpRcd] = t.[EmpRcd]
+               AND positionMatch.[PositionNumber] = t.[PositionNumber]
+            WHERE t.[JobCode] IS NULL OR t.[JobCode] = '';
+            DROP TABLE #PeopleSoftJobs;
+            """, destination)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            await update.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    public static string BuildNamesQuery() =>
+        """
+        SELECT EMPLID AS employee_id, NAME AS employee_name
+        FROM CAES_HCMODS.UCD_PS_NAMES_V
+        """;
+
+    // PS_JOB_V columns verified against the warehouse 2026-07-30.
+    public static string BuildJobCodeQuery() =>
+        """
+        SELECT EMPLID AS employee_id, EMPL_RCD AS emp_rcd, EFFDT AS eff_dt, EFFSEQ AS eff_seq,
+            POSITION_NBR AS position_number, SUBSTR(JOBCODE, -4) AS title_code
+        FROM CAES_HCMODS.PS_JOB_V
+        WHERE JOBCODE <> 'CONV'
+          AND JOBCODE NOT LIKE ' %'
+          AND EFFDT <= ?
+        """;
+
+    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    // Column names verified against the warehouse 2026-07-30 (ALL_TAB_COLUMNS for
+    // both labor views). PAY_END_DT is the pay period end date used for the window
+    // filter; UC_EARN_END_DT also exists but the 2025 notes say not to use it.
+    public static string BuildSalaryQuery(IReadOnlyList<string> projects204, int fteDenominatorHours) =>
+        $"""
+        SELECT
+            JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ || '_' || EMPLID || '_' || EMPL_RCD || '_' || ERNCD || '_' || RUN_ID AS labor_transaction_id,
+            NULLIF(TRIM(OPERATING_UNIT), '') AS entity,
+            NULLIF(TRIM(FUND_CODE), '') AS fund,
+            NULLIF(TRIM(DEPTID_CF), '') AS financial_department,
+            NULLIF(TRIM(UC_DEPTID_ROLLUP), '') AS parent_department,
+            NULLIF(TRIM(ACCOUNT), '') AS account,
+            NULLIF(TRIM(CLASS_FLD), '') AS purpose,
+            NULLIF(TRIM(PROGRAM_CODE), '') AS program,
+            NULLIF(TRIM(PROJECT_ID), '') AS project,
+            NULLIF(TRIM(CHARTFIELD1), '') AS activity,
+            NULLIF(TRIM(ERNCD), '') AS erncd,
+            NULLIF(TRIM(UC_EARNCD_DESCR), '') AS ern_description,
+            NULLIF(TRIM(EMPLID), '') AS employee_id,
+            NULLIF(TRIM(POSITION_NBR), '') AS position_number,
+            EFFDT AS eff_dt,
+            NULLIF(TRIM(SUBSTR(JOBCODE, -4)), '') AS job_code,
+            HOURS1 AS hours,
+            MONETARY_AMOUNT AS amount,
+            CASE WHEN HOURS1 <> 0 THEN MONETARY_AMOUNT / HOURS1 END AS pay_rate,
+            HOURS1 / {fteDenominatorHours} AS calculated_fte,
+            PAY_END_DT AS pay_period_end_date,
+            'S' AS fringe_benefit_salary_cd,
+            UC_PCT_TOT_PAY AS paid_percent,
+            UC_DRV_EFT_PCT AS ern_derived_percent,
+            FISCAL_YEAR AS fiscal_year,
+            TO_CHAR(ACCOUNTING_PERIOD) AS period,
+            EMPL_RCD AS emp_rcd,
+            EFFSEQ AS eff_seq
+        FROM CAES_HCMODS.PS_UC_LL_SAL_DTL_V
+        WHERE BUSINESS_UNIT IN ('DVCMP','UCANR')
+          AND OPERATING_UNIT IN ('3310','3110')
+          AND DML_IND <> 'D'
+          AND PAY_END_DT BETWEEN ? AND ?
+          AND NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL
+          AND (FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78'){Source204Arm(projects204)})
+        """;
+
+    // Column names verified against the warehouse 2026-07-30. The fringe view has
+    // no JOBCODE, hours, or percent columns; job_code is backfilled by the title
+    // code enrichment step.
+    public static string BuildFringeQuery(IReadOnlyList<string> projects204) =>
+        $"""
+        SELECT
+            JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ || '_' || EMPLID || '_' || EMPL_RCD || '_' || 'XXX' || '_' || RUN_ID AS labor_transaction_id,
+            NULLIF(TRIM(OPERATING_UNIT), '') AS entity,
+            NULLIF(TRIM(FUND_CODE), '') AS fund,
+            NULLIF(TRIM(DEPTID_CF), '') AS financial_department,
+            NULLIF(TRIM(UC_DEPTID_ROLLUP), '') AS parent_department,
+            NULLIF(TRIM(ACCOUNT), '') AS account,
+            NULLIF(TRIM(CLASS_FLD), '') AS purpose,
+            NULLIF(TRIM(PROGRAM_CODE), '') AS program,
+            NULLIF(TRIM(PROJECT_ID), '') AS project,
+            NULLIF(TRIM(CHARTFIELD1), '') AS activity,
+            'XXX' AS erncd,
+            CAST(NULL AS VARCHAR2(120)) AS ern_description,
+            NULLIF(TRIM(EMPLID), '') AS employee_id,
+            NULLIF(TRIM(POSITION_NBR), '') AS position_number,
+            EFFDT AS eff_dt,
+            CAST(NULL AS VARCHAR2(24)) AS job_code,
+            0 AS hours,
+            MONETARY_AMOUNT AS amount,
+            CAST(NULL AS DECIMAL(17,4)) AS pay_rate,
+            0 AS calculated_fte,
+            PAY_END_DT AS pay_period_end_date,
+            'F' AS fringe_benefit_salary_cd,
+            CAST(NULL AS DECIMAL(7,4)) AS paid_percent,
+            CAST(NULL AS DECIMAL(7,4)) AS ern_derived_percent,
+            FISCAL_YEAR AS fiscal_year,
+            TO_CHAR(ACCOUNTING_PERIOD) AS period,
+            EMPL_RCD AS emp_rcd,
+            EFFSEQ AS eff_seq
+        FROM CAES_HCMODS.PS_UC_LL_FRNG_DTL_V
+        WHERE BUSINESS_UNIT IN ('DVCMP','UCANR')
+          AND OPERATING_UNIT IN ('3310','3110')
+          AND DML_IND <> 'D'
+          AND PAY_END_DT BETWEEN ? AND ?
+          AND NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL
+          AND (FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78'){Source204Arm(projects204)})
+        """;
+
+    private static string Source204Arm(IReadOnlyList<string> projects204) =>
+        projects204.Count > 0 ? $" OR PROJECT_ID IN ({ImportSql.QuoteList(projects204)})" : string.Empty;
+}

--- a/server.core/Import/UcPathTransactionsImportService.cs
+++ b/server.core/Import/UcPathTransactionsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class UcPathTransactionsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string HcmLinkedServer = "AIT_BISTG_PRD-CAES_HCMODS_APPUSER";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -67,15 +66,7 @@ public sealed class UcPathTransactionsImportService
 
     public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());
@@ -83,7 +74,7 @@ public sealed class UcPathTransactionsImportService
         await using var destination = new SqlConnection(destinationConnectionString);
         await destination.OpenAsync(cancellationToken);
 
-        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var projects204 = await ImportSql.ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
         var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
         var fteDenominatorHours = ImportSql.HoursInFederalFiscalYear(cycleEnd.Year);
 
@@ -270,19 +261,6 @@ public sealed class UcPathTransactionsImportService
           AND JOBCODE NOT LIKE ' %'
           AND EFFDT <= ?
         """;
-
-    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
-    {
-        var values = new List<string>();
-        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
-        await using var reader = await command.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            values.Add(reader.GetString(0));
-        }
-
-        return values;
-    }
 
     // Column names verified against the warehouse 2026-07-30 (ALL_TAB_COLUMNS for
     // both labor views). PAY_END_DT is the pay period end date used for the window

--- a/server/Controllers/ImportRunsController.cs
+++ b/server/Controllers/ImportRunsController.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Server.Authorization;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Models.ImportRuns;
+using System.Security.Claims;
+
+namespace Server.Controllers;
+
+public interface IImportRunStarter
+{
+    void Start(int runId);
+}
+
+public sealed class ImportRunStarter(IServiceScopeFactory scopeFactory, ILogger<ImportRunStarter> logger)
+    : IImportRunStarter
+{
+    public void Start(int runId)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var orchestrator = scope.ServiceProvider.GetRequiredService<ImportRunOrchestrator>();
+                await orchestrator.RunAsync(runId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Import run {RunId} crashed outside stage handling", runId);
+            }
+        });
+    }
+}
+
+public class ImportRunsController : ApiControllerBase
+{
+    private readonly AppDbContext _appDb;
+    private readonly IImportStageProvider _stageProvider;
+    private readonly IImportRunStarter _runStarter;
+    private readonly IImportReadinessCheck _readinessCheck;
+
+    public ImportRunsController(
+        AppDbContext appDb,
+        IImportStageProvider stageProvider,
+        IImportRunStarter runStarter,
+        IImportReadinessCheck readinessCheck)
+    {
+        _appDb = appDb;
+        _stageProvider = stageProvider;
+        _runStarter = runStarter;
+        _readinessCheck = readinessCheck;
+    }
+
+    // POST api/importruns
+    // Cycle dates come from the confirmed fiscal period, never from the client:
+    // a stale browser tab must not be able to import the wrong year.
+    [HttpPost]
+    public async Task<ActionResult<ImportRunDto>> Start(CancellationToken cancellationToken)
+    {
+        var workflowRun = await _appDb.WorkflowRuns
+            .SingleOrDefaultAsync(r => r.IsCurrent, cancellationToken);
+        if (workflowRun is null)
+        {
+            return Conflict("No fiscal period has been confirmed in Project Identification.");
+        }
+
+        if (await _appDb.ImportRuns.AnyAsync(r => r.Status == ImportRunStatus.Running, cancellationToken))
+        {
+            return Conflict("An import run is already in progress.");
+        }
+
+        if (await _readinessCheck.GetBlockingIssueAsync(
+                workflowRun.CycleStart, workflowRun.CycleEnd, cancellationToken) is { } blockingIssue)
+        {
+            return Conflict(blockingIssue);
+        }
+
+        var run = new ImportRun
+        {
+            CycleStart = workflowRun.CycleStart,
+            CycleEnd = workflowRun.CycleEnd,
+            Status = ImportRunStatus.Running,
+            TriggeredByEntraId = User.GetEntraId(),
+            TriggeredByName = User.FindFirst("name")?.Value ?? User.Identity?.Name,
+            TriggeredByEmail = User.FindFirst("preferred_username")?.Value ?? User.FindFirst(ClaimTypes.Email)?.Value,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages = _stageProvider.StageNames
+                .Select((name, i) => new ImportRunStage { Name = name, Ordinal = i, Status = ImportStageStatus.Pending })
+                .ToList(),
+        };
+
+        _appDb.ImportRuns.Add(run);
+        await _appDb.SaveChangesAsync(cancellationToken);
+
+        _runStarter.Start(run.Id);
+
+        return ImportRunDto.From(run);
+    }
+
+    // GET api/importruns/current
+    [HttpGet("current")]
+    public async Task<ActionResult<ImportRunDto>> Current(CancellationToken cancellationToken)
+    {
+        var run = await _appDb.ImportRuns
+            .Include(r => r.Stages)
+            .OrderByDescending(r => r.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return run is null ? NoContent() : ImportRunDto.From(run);
+    }
+}

--- a/server/Models/ImportRuns/ImportRunDtos.cs
+++ b/server/Models/ImportRuns/ImportRunDtos.cs
@@ -1,0 +1,45 @@
+using Server.Core.Domain;
+
+namespace Server.Models.ImportRuns;
+
+public sealed record ImportRunStageDto(
+    string Name,
+    int Ordinal,
+    string Status,
+    int? RowCount,
+    string? Detail,
+    DateTimeOffset? StartedAt,
+    DateTimeOffset? CompletedAt,
+    string? ErrorDetail);
+
+public sealed record ImportRunDto(
+    int Id,
+    DateOnly CycleStart,
+    DateOnly CycleEnd,
+    string Status,
+    string? TriggeredByName,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? CompletedAt,
+    IReadOnlyList<ImportRunStageDto> Stages)
+{
+    public static ImportRunDto From(ImportRun run) => new(
+        run.Id,
+        run.CycleStart,
+        run.CycleEnd,
+        run.Status,
+        run.TriggeredByName,
+        run.StartedAt,
+        run.CompletedAt,
+        run.Stages
+            .OrderBy(stage => stage.Ordinal)
+            .Select(stage => new ImportRunStageDto(
+                stage.Name,
+                stage.Ordinal,
+                stage.Status,
+                stage.RowCount,
+                stage.Detail,
+                stage.StartedAt,
+                stage.CompletedAt,
+                stage.ErrorDetail))
+            .ToList());
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Server.Authorization;
+using Server.Controllers;
 using Server.Core.Data;
 using Server.Import;
 using Server.Core.Import;
@@ -59,6 +60,14 @@ builder.Services.AddSingleton<IFlatFileImportRegistry, FlatFileImportRegistry>()
 builder.Services.AddScoped<IFlatFileImportService, FlatFileImportService>();
 builder.Services.AddScoped<IProjectIdentificationService, ProjectIdentificationService>();
 builder.Services.AddScoped<IProjectListService, ProjectListService>();
+builder.Services.AddScoped<ImportRunOrchestrator>();
+builder.Services.AddSingleton<IImportRunStarter, ImportRunStarter>();
+builder.Services.AddScoped<ChartSegmentsImportService>();
+builder.Services.AddScoped<AeTransactionsImportService>();
+builder.Services.AddScoped<UcPathTransactionsImportService>();
+builder.Services.AddScoped<SprocStageService>();
+builder.Services.AddScoped<IImportReadinessCheck, ImportReadinessCheck>();
+builder.Services.AddScoped<IImportStageProvider, ImportStageProvider>();
 // add auth policies here
 
 // add db context (check secrets first, then config, then default)

--- a/tests/server.tests/Data/DatamartConnectionTests.cs
+++ b/tests/server.tests/Data/DatamartConnectionTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Tests.Data;
+
+public class DatamartConnectionTests
+{
+    [Fact]
+    public void Resolve_prefers_environment_variable_over_named_connection()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [DatamartConnection.EnvironmentVariableName] = "env-connection",
+            [$"ConnectionStrings:{DatamartConnection.ConnectionStringName}"] = "named-connection",
+        });
+
+        var connectionString = DatamartConnection.Resolve(configuration);
+
+        connectionString.Should().Be("env-connection");
+    }
+
+    [Fact]
+    public void Resolve_skips_blank_environment_variable_and_uses_named_connection()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [DatamartConnection.EnvironmentVariableName] = "   ",
+            [$"ConnectionStrings:{DatamartConnection.ConnectionStringName}"] = "named-connection",
+        });
+
+        var connectionString = DatamartConnection.Resolve(configuration);
+
+        connectionString.Should().Be("named-connection");
+    }
+
+    [Fact]
+    public void Resolve_throws_when_nothing_is_configured()
+    {
+        var configuration = BuildConfiguration([]);
+
+        var resolve = () => DatamartConnection.Resolve(configuration);
+
+        resolve.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{DatamartConnection.EnvironmentVariableName}*");
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/tests/server.tests/Import/AeTransactionsImportServiceTests.cs
+++ b/tests/server.tests/Import/AeTransactionsImportServiceTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class AeTransactionsImportServiceTests
+{
+    private static readonly string[] Periods = ["Jul-24", "Aug-24"];
+    private static readonly string[] Depts = ["APLS001", "AANS001"];
+    private static readonly string[] Bcbs = ["BCBS001"];
+    private static readonly string[] Projects = ["K30V4ALIUR"];
+
+    [Fact]
+    public void BuildRemoteQuery_filters_to_actuals_and_periods()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, Bcbs, Projects);
+
+        query.Should().Contain("FROM ae_dwh.transactional_listing_report");
+        query.Should().Contain("actual_flag = 'A'");
+        query.Should().Contain("period_name IN ('Jul-24','Aug-24')");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_casts_the_wide_net_with_dept_204_and_bcbs_arms()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, Bcbs, Projects);
+
+        query.Should().Contain("financial_department IN ('APLS001','AANS001')");
+        query.Should().Contain("project IN ('K30V4ALIUR')");
+        query.Should().Contain("financial_department IN ('BCBS001') AND fund = '13U02'");
+        // the wide net has no purpose, account, or activity filters (the segment
+        // columns themselves appear in the select list, so assert on filter shapes)
+        query.Should().NotContain("purpose NOT IN");
+        query.Should().NotContain("account NOT LIKE");
+        query.Should().NotContain("activity NOT IN");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_omits_empty_optional_arms()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, [], []);
+
+        query.Should().NotContain("13U02");
+        query.Should().NotContain("project IN");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_requires_departments()
+    {
+        var act = () => AeTransactionsImportService.BuildRemoteQuery(Periods, [], Bcbs, Projects);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*CAES/ANR department list is empty*");
+    }
+}

--- a/tests/server.tests/Import/ChartSegmentsImportServiceTests.cs
+++ b/tests/server.tests/Import/ChartSegmentsImportServiceTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ChartSegmentsImportServiceTests
+{
+    [Fact]
+    public void Segments_cover_all_eight_erp_tables_in_stage_order()
+    {
+        ChartSegmentsImportService.Segments.Select(s => s.SourceTable).Should().Equal(
+            "ae_dwh.erp_entity", "ae_dwh.erp_fund", "ae_dwh.erp_fin_dept", "ae_dwh.erp_account",
+            "ae_dwh.erp_purpose", "ae_dwh.erp_program", "ae_dwh.erp_project", "ae_dwh.erp_activity");
+        ChartSegmentsImportService.Segments.Select(s => s.SegmentName).Should().Equal(
+            "Entity", "Fund", "FinancialDepartment", "Account",
+            "Purpose", "Program", "Project", "Activity");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_selects_a_segment_name_literal_from_the_source_table()
+    {
+        var query = ChartSegmentsImportService.BuildRemoteQuery("Fund", "ae_dwh.erp_fund");
+
+        query.Should().Contain("CAST('Fund' AS VARCHAR(30)) AS segment_name");
+        query.Should().Contain("FROM ae_dwh.erp_fund");
+        query.Should().Contain("parent_level_0_code");
+        query.Should().Contain("parent_level_5_code");
+        query.Should().NotMatchRegex(@"parent_level_\d[,\s]");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_rejects_unknown_segment_names()
+    {
+        var act = () => ChartSegmentsImportService.BuildRemoteQuery("Robert'); DROP TABLE", "ae_dwh.erp_fund");
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/server.tests/Import/ImportRunsControllerTests.cs
+++ b/tests/server.tests/Import/ImportRunsControllerTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Server.Controllers;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Models.ImportRuns;
+using System.Security.Claims;
+
+namespace Server.Tests.Import;
+
+public class ImportRunsControllerTests
+{
+    private sealed class FakeStageProvider : IImportStageProvider
+    {
+        public IReadOnlyList<string> StageNames => ImportStageNames.All;
+        public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context) =>
+            StageNames.Select(name => ImportStage.FromRowCount(name, _ => Task.FromResult(0))).ToList();
+    }
+
+    private sealed class RecordingRunStarter : IImportRunStarter
+    {
+        public List<int> StartedRunIds { get; } = [];
+        public void Start(int runId) => StartedRunIds.Add(runId);
+    }
+
+    private sealed class FakeReadinessCheck(string? blockingIssue) : IImportReadinessCheck
+    {
+        public Task<string?> GetBlockingIssueAsync(
+            DateOnly cycleStart,
+            DateOnly cycleEnd,
+            CancellationToken cancellationToken) => Task.FromResult(blockingIssue);
+    }
+
+    private static async Task<WorkflowRun> SeedWorkflowRunAsync(AppDbContext db)
+    {
+        var run = new WorkflowRun
+        {
+            FiscalYear = "FY25",
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            IsCurrent = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.WorkflowRuns.Add(run);
+        await db.SaveChangesAsync();
+        return run;
+    }
+
+    private static ImportRunsController CreateController(
+        AppDbContext db, RecordingRunStarter starter, string? blockingIssue = null)
+    {
+        var controller = new ImportRunsController(
+            db, new FakeStageProvider(), starter, new FakeReadinessCheck(blockingIssue));
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("name", "Rob Martinsen"), new Claim("preferred_username", "rob@ucdavis.edu")],
+                    "test")),
+            },
+        };
+        return controller;
+    }
+
+    [Fact]
+    public async Task Start_creates_run_with_all_pending_stages_and_starts_it()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        await SeedWorkflowRunAsync(db);
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        var dto = result.Value!;
+        dto.Status.Should().Be(ImportRunStatus.Running);
+        dto.CycleStart.Should().Be(new DateOnly(2024, 10, 1));
+        dto.CycleEnd.Should().Be(new DateOnly(2025, 9, 30));
+        dto.Stages.Should().HaveCount(13);
+        dto.Stages.Should().OnlyContain(s => s.Status == ImportStageStatus.Pending);
+        dto.Stages.Select(s => s.Name).Should().ContainInOrder(ImportStageNames.All);
+        starter.StartedRunIds.Should().Equal(dto.Id);
+        (await db.ImportRuns.Include(r => r.Stages).SingleAsync()).Stages.Should().HaveCount(13);
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_a_run_is_already_running()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        db.ImportRuns.Add(new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+        await SeedWorkflowRunAsync(db);
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+        starter.StartedRunIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_project_identification_is_not_ready()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var starter = new RecordingRunStarter();
+        await SeedWorkflowRunAsync(db);
+        var controller = CreateController(
+            db, starter, "Unresolved project issues exist; resolve them in Project Identification first.");
+
+        var result = await controller.Start(CancellationToken.None);
+
+        var conflict = result.Result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().Be("Unresolved project issues exist; resolve them in Project Identification first.");
+        starter.StartedRunIds.Should().BeEmpty();
+        (await db.ImportRuns.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_no_fiscal_period_is_confirmed()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+        starter.StartedRunIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Current_returns_latest_run_or_204()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var controller = CreateController(db, new RecordingRunStarter());
+
+        (await controller.Current(CancellationToken.None)).Result.Should().BeOfType<NoContentResult>();
+
+        db.ImportRuns.AddRange(
+            new ImportRun { CycleStart = new(2023, 10, 1), CycleEnd = new(2024, 9, 30), Status = ImportRunStatus.Succeeded, StartedAt = DateTimeOffset.UtcNow.AddDays(-2) },
+            new ImportRun { CycleStart = new(2024, 10, 1), CycleEnd = new(2025, 9, 30), Status = ImportRunStatus.Failed, StartedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var dto = (await controller.Current(CancellationToken.None)).Value!;
+        dto.Status.Should().Be(ImportRunStatus.Failed);
+        dto.CycleStart.Should().Be(new DateOnly(2024, 10, 1));
+    }
+}

--- a/tests/server.tests/Import/ImportSqlTests.cs
+++ b/tests/server.tests/Import/ImportSqlTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportSqlTests
+{
+    [Fact]
+    public void PeriodNames_spans_year_boundaries_in_en_us()
+    {
+        ImportSql.PeriodNames(new DateOnly(2024, 11, 15), new DateOnly(2025, 2, 1))
+            .Should().Equal("Nov-24", "Dec-24", "Jan-25", "Feb-25");
+    }
+
+    [Fact]
+    public void QuoteList_doubles_embedded_quotes()
+    {
+        ImportSql.QuoteList(["ABC", "O'Neil"]).Should().Be("'ABC','O''Neil'");
+    }
+
+    [Fact]
+    public void HoursInFederalFiscalYear_handles_leap_cycle()
+    {
+        ImportSql.HoursInFederalFiscalYear(2024).Should().Be(2096);
+        ImportSql.HoursInFederalFiscalYear(2025).Should().Be(2088);
+    }
+
+    [Fact]
+    public void BufferedWindow_extends_three_months_each_side()
+    {
+        ImportSql.BufferedWindow(new DateOnly(2024, 10, 1), new DateOnly(2025, 9, 30))
+            .Should().Be((new DateOnly(2024, 7, 1), new DateOnly(2025, 12, 30)));
+    }
+}

--- a/tests/server.tests/Import/ImportStageProviderTests.cs
+++ b/tests/server.tests/Import/ImportStageProviderTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportStageProviderTests
+{
+    private static ImportStageProvider CreateProvider()
+    {
+        var db = TestDbContextFactory.CreateDataInMemory();
+        var config = new ConfigurationBuilder().Build();
+        return new ImportStageProvider(
+            new ChartSegmentsImportService(db, config, NullLogger<ChartSegmentsImportService>.Instance),
+            new AeTransactionsImportService(db, config, NullLogger<AeTransactionsImportService>.Instance),
+            new UcPathTransactionsImportService(db, config, NullLogger<UcPathTransactionsImportService>.Instance),
+            new SprocStageService(db, config));
+    }
+
+    [Fact]
+    public void Stage_names_match_the_canonical_order()
+    {
+        CreateProvider().StageNames.Should().Equal(ImportStageNames.All);
+    }
+
+    [Fact]
+    public void BuildStages_produces_one_stage_per_name_in_order()
+    {
+        var context = new ImportRunContext(1, new DateOnly(2024, 10, 1), new DateOnly(2025, 9, 30));
+        var stages = CreateProvider().BuildStages(context);
+
+        stages.Select(s => s.Name).Should().Equal(ImportStageNames.All);
+    }
+}

--- a/tests/server.tests/Import/UcPathTransactionsImportServiceTests.cs
+++ b/tests/server.tests/Import/UcPathTransactionsImportServiceTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class UcPathTransactionsImportServiceTests
+{
+    private static readonly string[] Projects = ["K30V4ALIUR", "SP1A242572"];
+
+    [Fact]
+    public void BuildSalaryQuery_applies_the_2025_source_filter_with_204_arm()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2088);
+
+        query.Should().Contain("FROM CAES_HCMODS.PS_UC_LL_SAL_DTL_V");
+        query.Should().Contain("BUSINESS_UNIT IN ('DVCMP','UCANR')");
+        query.Should().Contain("OPERATING_UNIT IN ('3310','3110')");
+        query.Should().Contain("DML_IND <> 'D'");
+        query.Should().Contain("FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78')");
+        query.Should().Contain("PROJECT_ID IN ('K30V4ALIUR','SP1A242572')");
+        // pay period end date is the window filter, bound as placeholders
+        query.Should().Contain("PAY_END_DT BETWEEN ? AND ?");
+    }
+
+    [Fact]
+    public void BuildSalaryQuery_computes_fte_payrate_and_salary_marker_in_source_sql()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2096);
+
+        query.Should().Contain("HOURS1 / 2096");    // CalculatedFte denominator
+        query.Should().Contain("'S' AS fringe_benefit_salary_cd");
+        query.Should().Contain("NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL");
+    }
+
+    [Fact]
+    public void BuildSalaryQuery_uses_the_verified_view_column_names()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2088);
+
+        query.Should().Contain("JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ");
+        query.Should().Contain("HOURS1 AS hours");
+        query.Should().Contain("MONETARY_AMOUNT AS amount");
+        // JOBCODE holds 6-char values like '003252'; the title code is the last 4
+        query.Should().Contain("SUBSTR(JOBCODE, -4)");
+        query.Should().Contain("UC_EARNCD_DESCR), '') AS ern_description");
+        query.Should().Contain("UC_PCT_TOT_PAY AS paid_percent");
+        query.Should().Contain("UC_DRV_EFT_PCT AS ern_derived_percent");
+        query.Should().Contain("TO_CHAR(ACCOUNTING_PERIOD) AS period");
+        // absent from both labor views
+        query.Should().NotContain("FINANCE_DOC_TYPE_CD");
+        query.Should().NotContain("RATE_TYPE_CD");
+    }
+
+    [Fact]
+    public void BuildFringeQuery_marks_fringe_rows_with_placeholder_ern()
+    {
+        var query = UcPathTransactionsImportService.BuildFringeQuery(Projects);
+
+        query.Should().Contain("FROM CAES_HCMODS.PS_UC_LL_FRNG_DTL_V");
+        query.Should().Contain("'XXX' AS erncd");
+        query.Should().Contain("'F' AS fringe_benefit_salary_cd");
+        query.Should().Contain("0 AS calculated_fte");
+    }
+
+    [Fact]
+    public void BuildFringeQuery_uses_the_verified_view_column_names()
+    {
+        var query = UcPathTransactionsImportService.BuildFringeQuery(Projects);
+
+        query.Should().Contain("JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ");
+        query.Should().Contain("MONETARY_AMOUNT AS amount");
+        // the fringe view has no JOBCODE; enrichment backfills it
+        query.Should().Contain("CAST(NULL AS VARCHAR2(24)) AS job_code");
+        query.Should().Contain("CAST(NULL AS VARCHAR2(120)) AS ern_description");
+        query.Should().NotContain("FINANCE_DOC_TYPE_CD");
+        query.Should().NotContain("RATE_TYPE_CD");
+    }
+
+    [Fact]
+    public void Queries_omit_the_204_arm_when_no_projects_exist()
+    {
+        UcPathTransactionsImportService.BuildSalaryQuery([], 2088).Should().NotContain("PROJECT_ID IN");
+        UcPathTransactionsImportService.BuildFringeQuery([]).Should().NotContain("PROJECT_ID IN");
+    }
+
+    [Fact]
+    public void BuildNamesQuery_prefers_the_names_view()
+    {
+        var query = UcPathTransactionsImportService.BuildNamesQuery();
+
+        query.Should().Contain("CAES_HCMODS.UCD_PS_NAMES_V");
+    }
+
+    [Fact]
+    public void BuildJobCodeQuery_filters_conversion_rows_and_bounds_effdt()
+    {
+        var query = UcPathTransactionsImportService.BuildJobCodeQuery();
+
+        query.Should().Contain("CAES_HCMODS.PS_JOB_V");
+        query.Should().Contain("JOBCODE <> 'CONV'");
+        query.Should().Contain("EFFDT <= ?");
+    }
+}


### PR DESCRIPTION
Part of the #45 split (#31), stacked on #52 (run/stage infrastructure); retarget as parents merge. The domain half of the backend:

- The thirteen-stage pipeline composed onto the infrastructure: eight ChartSegments reference pulls, build projects, AE transactions, UCPath transactions, seed segment classifications, classify — wired into DI with trigger and status endpoints.
- AE import casts the wide net: actual_flag = 'A', confirmed cycle plus a 3 month buffer, CAES/ANR departments OR 204 projects OR BCBS on 13U02, streamed via linked server pass-through and SqlBulkCopy in a delete-and-reload transaction. Import timeout is an hour: the linked server streams ~465k rows row by row (10 to 15 minutes).
- UCPath import rewrites usp_LoadAELaborTransactions in C#: salary and fringe pulls with the 2025 source filter plus the 204 arm, FTE calculation, name enrichment (UCD_PS_NAMES_V, verified one row per EMPLID) and title code enrichment (PS_JOB_V). All source columns verified against the HCM ODS. The salary pull also carries UC_EARNCD_DESCR so the seed sproc fills Ern descriptions from local rows, with no separate backfill trip to the HCM server.
- Cycle handling matches #48: the trigger endpoint sources dates from the confirmed WorkflowRun server side (a stale browser tab can never import the wrong year), 409s when project identification has unresolved issues via the shared ImportBlockingIssueForCycle definition, and the build projects stage passes the run's cycle to the parameterized sproc.
- A complete FY25 run (all thirteen stages) succeeded end to end locally.

Open questions from #31 (BCBS purpose 45 handling, UCPath filter scope, Ern display label) remain pending Shannon. Frontend is #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)