### PR TITLE
Expense import: Data Import workflow stage UI

### DIFF
--- a/client/src/components/dataImport/DataImportStage.tsx
+++ b/client/src/components/dataImport/DataImportStage.tsx
@@ -1,0 +1,219 @@
+import { SectionPanel } from '@/components/SectionPanel.tsx';
+import {
+  bufferedImportWindow,
+  importRunQueryOptions,
+  startImportRun,
+} from '@/queries/importRuns.ts';
+import {
+  projectIdentificationSetupQueryOptions,
+  type ProjectIdentificationSetupResponse,
+} from '@/queries/projectIdentification.ts';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { ImportRunStage } from '@/queries/importRuns.ts';
+
+const STATUS_BADGES: Record<ImportRunStage['status'], string> = {
+  Failed: 'badge badge-error badge-outline',
+  Pending: 'badge badge-ghost',
+  Running: 'badge badge-info',
+  Succeeded: 'badge badge-success badge-outline',
+};
+
+export function DataImportStage() {
+  const setupQuery = useQuery(projectIdentificationSetupQueryOptions());
+
+  if (setupQuery.isLoading) {
+    return <p>Loading data import...</p>;
+  }
+
+  if (setupQuery.isError || !setupQuery.data) {
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load reporting cycle</h2>
+          <p>
+            The fiscal period from Project Identification could not be loaded.
+          </p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={setupQuery.isFetching}
+            onClick={() => void setupQuery.refetch()}
+            type="button"
+          >
+            {setupQuery.isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return <DataImportStageContent setup={setupQuery.data} />;
+}
+
+function DataImportStageContent({
+  setup,
+}: {
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  const queryClient = useQueryClient();
+  const { data: run } = useQuery(importRunQueryOptions());
+
+  const start = useMutation({
+    mutationFn: startImportRun,
+    onSuccess: (created) => {
+      queryClient.setQueryData(importRunQueryOptions().queryKey, created);
+    },
+  });
+
+  const periodLabel =
+    setup.fiscalPeriodOptions.find(
+      (option) => option.fiscalYear === setup.fiscalYear
+    )?.label ?? '';
+  const { windowEnd, windowStart } = bufferedImportWindow(
+    setup.cycleStart,
+    setup.cycleEnd
+  );
+
+  const isRunning = run?.status === 'Running' || start.isPending;
+  const failedStages =
+    run?.stages.filter((stage) => stage.status === 'Failed') ?? [];
+  const sortedStages = [...(run?.stages ?? [])].sort(
+    (a, b) => a.ordinal - b.ordinal
+  );
+
+  return (
+    <SectionPanel eyebrow="Expense Data" title="Data Import">
+      <div className="space-y-4 p-4">
+        <p className="text-sm text-slate-600">
+          Pulls AE and UCPath transactions for the reporting cycle and seeds
+          new chart string segments for classification. The fiscal year comes
+          from the Project Identification step. Pulling in transactions may
+          take several hours, and the import keeps running in the background
+          if you leave this page.
+        </p>
+
+        <p className="text-sm text-slate-600">
+          Transactions are imported for {formatDate(windowStart)} through{' '}
+          {formatDate(windowEnd)}, the fiscal year with a 3 month buffer on
+          each end. We intentionally cast a wide net to make sure we&apos;re
+          pulling in all relevant transactions. Transactions from outside the
+          fiscal year will be excluded for the final report.
+        </p>
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <label className="form-control w-full">
+            <span className="label-text">Fiscal year</span>
+            <select
+              className="select select-bordered w-full"
+              disabled
+              value={setup.fiscalYear}
+            >
+              <option value={setup.fiscalYear}>
+                {setup.fiscalYear.replace('FY', 'FY:')}
+              </option>
+            </select>
+          </label>
+
+          <label className="form-control w-full">
+            <span className="label-text">Period</span>
+            <select
+              className="select select-bordered w-full"
+              disabled
+              value={periodLabel}
+            >
+              <option>{periodLabel}</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            className="btn btn-primary"
+            disabled={isRunning}
+            onClick={() => start.mutate()}
+            type="button"
+          >
+            Start Import
+          </button>
+        </div>
+
+        {start.error ? (
+          <div className="alert alert-error" role="alert">
+            <span>
+              {start.error instanceof Error
+                ? start.error.message
+                : 'Failed to start the import.'}
+            </span>
+          </div>
+        ) : null}
+
+        {failedStages.map((stage) => (
+          <div className="alert alert-error" key={stage.ordinal} role="alert">
+            <span>
+              {stage.name}: {stage.errorDetail}
+            </span>
+          </div>
+        ))}
+
+        {run ? (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+              <span className={STATUS_BADGES[run.status]}>{run.status}</span>
+              <span>
+                Cycle {formatDate(run.cycleStart)} through{' '}
+                {formatDate(run.cycleEnd)}
+              </span>
+              {run.triggeredByName ? (
+                <span>Triggered by {run.triggeredByName}</span>
+              ) : null}
+              <span>Started {formatDateTime(run.startedAt)}</span>
+              {run.completedAt ? (
+                <span>Completed {formatDateTime(run.completedAt)}</span>
+              ) : null}
+            </div>
+
+            <table className="table table-zebra table-sm">
+              <thead>
+                <tr>
+                  <th>Stage</th>
+                  <th>Status</th>
+                  <th>Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedStages.map((stage) => (
+                  <tr key={stage.ordinal}>
+                    <td>{stage.name}</td>
+                    <td>
+                      <span className={STATUS_BADGES[stage.status]}>
+                        {stage.status}
+                      </span>
+                    </td>
+                    <td>{stage.detail ?? stage.rowCount?.toLocaleString() ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="rounded border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-slate-600">
+            No import has run yet for this cycle.
+          </div>
+        )}
+      </div>
+    </SectionPanel>
+  );
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}

--- a/client/src/components/dataImport/DataImportStage.tsx
+++ b/client/src/components/dataImport/DataImportStage.tsx
@@ -1,3 +1,4 @@
+import { HttpError } from '@/lib/api.ts';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
 import {
   bufferedImportWindow,
@@ -55,7 +56,8 @@ function DataImportStageContent({
   setup: ProjectIdentificationSetupResponse;
 }) {
   const queryClient = useQueryClient();
-  const { data: run } = useQuery(importRunQueryOptions());
+  const runQuery = useQuery(importRunQueryOptions());
+  const run = runQuery.data;
 
   const start = useMutation({
     mutationFn: startImportRun,
@@ -63,6 +65,29 @@ function DataImportStageContent({
       queryClient.setQueryData(importRunQueryOptions().queryKey, created);
     },
   });
+
+  if (runQuery.isLoading) {
+    return <p>Loading data import...</p>;
+  }
+
+  if (runQuery.isError) {
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load import status</h2>
+          <p>The current import run could not be loaded.</p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={runQuery.isFetching}
+            onClick={() => void runQuery.refetch()}
+            type="button"
+          >
+            {runQuery.isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const periodLabel =
     setup.fiscalPeriodOptions.find(
@@ -138,11 +163,7 @@ function DataImportStageContent({
 
         {start.error ? (
           <div className="alert alert-error" role="alert">
-            <span>
-              {start.error instanceof Error
-                ? start.error.message
-                : 'Failed to start the import.'}
-            </span>
+            <span>{startErrorMessage(start.error)}</span>
           </div>
         ) : null}
 
@@ -202,6 +223,28 @@ function DataImportStageContent({
       </div>
     </SectionPanel>
   );
+}
+
+// The server explains start rejections (no confirmed period, run already in
+// progress, readiness issues) as a plain-string Conflict body.
+function startErrorMessage(error: unknown) {
+  if (error instanceof HttpError) {
+    if (typeof error.body === 'string' && error.body.trim()) {
+      return error.body;
+    }
+
+    if (
+      error.body &&
+      typeof error.body === 'object' &&
+      'message' in error.body &&
+      typeof error.body.message === 'string' &&
+      error.body.message.trim()
+    ) {
+      return error.body.message;
+    }
+  }
+
+  return 'Failed to start the import.';
 }
 
 function formatDate(value: string) {

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -28,7 +28,7 @@
   }
 
   .workflow-stepper {
-    @apply grid border-b border-slate-200 bg-white px-4 shadow-sm lg:grid-cols-6 lg:px-8;
+    @apply grid border-b border-slate-200 bg-white px-4 shadow-sm lg:grid-cols-7 lg:px-8;
   }
 
   .workflow-step {

--- a/client/src/mockData.ts
+++ b/client/src/mockData.ts
@@ -14,37 +14,44 @@ export const workflowStages: WorkflowStage[] = [
   },
   {
     description:
+      'Pull AE and UCPath transactions for the cycle and seed new chart-string segments for classification.',
+    id: 'data-import',
+    number: 2,
+    title: 'Data Import',
+  },
+  {
+    description:
       'Classify new chart-string segments before they can be included in the AD419 report.',
     id: 'data-classification',
-    number: 2,
+    number: 3,
     title: 'Data Classification',
   },
   {
     description:
       'Confirm the right transactions are included before triggering auto-associations.',
     id: 'expense-review',
-    number: 3,
+    number: 4,
     title: 'Expense Review',
   },
   {
     description:
       'Run the rules engine to associate as many expenses as possible before manual review.',
     id: 'auto-associations',
-    number: 4,
+    number: 5,
     title: 'Auto-Associations',
   },
   {
     description:
       'Resolve flagged items after manual associations are complete.',
     id: 'post-association-review',
-    number: 5,
+    number: 6,
     title: 'Post-Association Review',
   },
   {
     description:
       'Generate the final files for ANR submission and cycle signoff.',
     id: 'final-reports',
-    number: 6,
+    number: 7,
     title: 'Final Reports',
   },
 ];

--- a/client/src/queries/importRuns.ts
+++ b/client/src/queries/importRuns.ts
@@ -51,16 +51,11 @@ const IMPORT_RUN_KEY = ['importRun'] as const;
 
 export const importRunQueryOptions = () =>
   queryOptions({
-    queryFn: async ({ signal }): Promise<ImportRun | null> => {
-      const response = await fetch('/api/importruns/current', { signal });
-      if (response.status === 204) {
-        return null;
-      }
-      if (!response.ok) {
-        throw new Error(`Failed to load import run (${response.status})`);
-      }
-      return (await response.json()) as ImportRun;
-    },
+    // fetchJson resolves undefined for the 204 "no run yet" response; the
+    // query needs null so react-query treats it as data, not a missing value.
+    queryFn: async ({ signal }): Promise<ImportRun | null> =>
+      (await fetchJson<ImportRun | null>('/api/importruns/current', {}, signal)) ??
+      null,
     queryKey: IMPORT_RUN_KEY,
     refetchInterval: (query) =>
       query.state.data?.status === 'Running' ? 2000 : false,

--- a/client/src/queries/importRuns.ts
+++ b/client/src/queries/importRuns.ts
@@ -1,0 +1,75 @@
+import { fetchJson } from '@/lib/api.ts';
+import { queryOptions } from '@tanstack/react-query';
+
+export interface ImportRunStage {
+  completedAt: string | null;
+  detail: string | null;
+  errorDetail: string | null;
+  name: string;
+  ordinal: number;
+  rowCount: number | null;
+  startedAt: string | null;
+  status: 'Failed' | 'Pending' | 'Running' | 'Succeeded';
+}
+
+export interface ImportRun {
+  completedAt: string | null;
+  cycleEnd: string;
+  cycleStart: string;
+  id: number;
+  stages: ImportRunStage[];
+  startedAt: string;
+  status: 'Failed' | 'Running' | 'Succeeded';
+  triggeredByName: string | null;
+}
+
+// Mirrors ImportSql.BufferedWindow on the server: months clamp to the last
+// day of the target month, matching .NET AddMonths.
+export function bufferedImportWindow(
+  cycleStart: string,
+  cycleEnd: string
+): { windowEnd: string; windowStart: string } {
+  return {
+    windowEnd: addMonths(cycleEnd, 3),
+    windowStart: addMonths(cycleStart, -3),
+  };
+}
+
+function addMonths(isoDate: string, months: number): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  const totalMonths = year * 12 + (month - 1) + months;
+  const targetYear = Math.floor(totalMonths / 12);
+  const targetMonth = (totalMonths % 12) + 1;
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth, 0)).getUTCDate();
+  const targetDay = Math.min(day, lastDay);
+  return `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(
+    targetDay
+  ).padStart(2, '0')}`;
+}
+
+const IMPORT_RUN_KEY = ['importRun'] as const;
+
+export const importRunQueryOptions = () =>
+  queryOptions({
+    queryFn: async ({ signal }): Promise<ImportRun | null> => {
+      const response = await fetch('/api/importruns/current', { signal });
+      if (response.status === 204) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to load import run (${response.status})`);
+      }
+      return (await response.json()) as ImportRun;
+    },
+    queryKey: IMPORT_RUN_KEY,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'Running' ? 2000 : false,
+  });
+
+// The server takes the cycle from the confirmed fiscal period; the client
+// sends no dates so a stale tab can never import the wrong year.
+export function startImportRun(): Promise<ImportRun> {
+  return fetchJson<ImportRun>('/api/importruns', {
+    method: 'POST',
+  });
+}

--- a/client/src/routes/(authenticated)/workflow.$stageId.tsx
+++ b/client/src/routes/(authenticated)/workflow.$stageId.tsx
@@ -4,6 +4,7 @@ import {
 } from '@/mockData.ts';
 import { workflowSnapshotQueryOptions } from '@/queries.ts';
 import { DataClassificationStage } from '@/components/dataClassification/DataClassificationStage.tsx';
+import { DataImportStage } from '@/components/dataImport/DataImportStage.tsx';
 import { ProjectIdentificationStage } from '@/components/ProjectIdentificationStage.tsx';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
 import { WorkflowShell } from '@/components/WorkflowShell.tsx';
@@ -51,6 +52,8 @@ function WorkflowStageRoute() {
           <ProjectIdentificationStage />
         ) : workflowStageId === 'data-classification' ? (
           <DataClassificationStage />
+        ) : workflowStageId === 'data-import' ? (
+          <DataImportStage />
         ) : (
           <SectionPanel title="Coming soon">
             <p>This step is coming soon.</p>

--- a/client/src/test/components/dataImport/DataImportStage.test.tsx
+++ b/client/src/test/components/dataImport/DataImportStage.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+
+const mockUser = {
+  email: 'shannon@example.edu',
+  id: 'user-1',
+  name: 'Shannon Taylor',
+  roles: ['User'],
+};
+
+const setupResponse = {
+  checklistItems: [],
+  completedCount: 7,
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  fiscalPeriodOptions: [
+    {
+      cycleEnd: '2026-09-30',
+      cycleStart: '2025-10-01',
+      fiscalYear: 'FY26',
+      label: 'FY:26 - Oct 2025 - Sep 2026',
+    },
+  ],
+  fiscalYear: 'FY26',
+  totalCount: 7,
+  workflowRunId: 1,
+};
+
+const succeededRun = {
+  completedAt: '2026-07-29T10:05:00Z',
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  id: 1,
+  stages: [
+    { completedAt: '2026-07-29T10:01:00Z', detail: null, errorDetail: null, name: 'ChartSegments: Fund', ordinal: 1, rowCount: 1200, startedAt: '2026-07-29T10:00:00Z', status: 'Succeeded' },
+    { completedAt: '2026-07-29T10:02:00Z', detail: '479 AE projects, 364 NIFA projects', errorDetail: null, name: 'Build projects', ordinal: 8, rowCount: 479, startedAt: '2026-07-29T10:01:00Z', status: 'Succeeded' },
+    { completedAt: '2026-07-29T10:05:00Z', detail: null, errorDetail: null, name: 'AE transactions', ordinal: 9, rowCount: 413_637, startedAt: '2026-07-29T10:02:00Z', status: 'Succeeded' },
+  ],
+  startedAt: '2026-07-29T10:00:00Z',
+  status: 'Succeeded',
+  triggeredByName: 'Rob',
+};
+
+function useSetupHandler() {
+  server.use(
+    http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+    http.get('/api/projectidentification/setup', () =>
+      HttpResponse.json(setupResponse)
+    )
+  );
+}
+
+describe('Data Import stage', () => {
+  it('shows the fiscal period from project identification with the buffered window', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => new HttpResponse(null, { status: 204 }))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByDisplayValue('FY:26')).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('FY:26 - Oct 2025 - Sep 2026')
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Jul 1, 2025/)).toBeInTheDocument();
+      expect(screen.getByText(/Dec 30, 2026/)).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows the latest run with per-stage row counts', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => HttpResponse.json(succeededRun))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByText('AE transactions')).toBeInTheDocument();
+      expect(screen.getByText('413,637')).toBeInTheDocument();
+      expect(
+        screen.getByText('479 AE projects, 364 NIFA projects')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /start import/i })).toBeEnabled();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('starts an import without posting dates and disables the button while running', async () => {
+    let started = false;
+    let postedBody: string | null = null;
+    const runningRun = { ...succeededRun, completedAt: null, id: 2, status: 'Running' };
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () =>
+        started ? HttpResponse.json(runningRun) : new HttpResponse(null, { status: 204 })
+      ),
+      http.post('/api/importruns', async ({ request }) => {
+        started = true;
+        postedBody = await request.text();
+        return HttpResponse.json(runningRun);
+      })
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      const start = await screen.findByRole('button', { name: /start import/i });
+      fireEvent.click(start);
+      await waitFor(() => expect(screen.getByRole('button', { name: /start import/i })).toBeDisabled());
+      // the server sources the cycle from the confirmed fiscal period
+      expect(postedBody).toBe('');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('surfaces stage errors', async () => {
+    const failedRun = {
+      ...succeededRun,
+      id: 3,
+      stages: [
+        { completedAt: '2026-07-29T10:02:00Z', detail: null, errorDetail: 'warehouse offline', name: 'AE transactions', ordinal: 9, rowCount: null, startedAt: '2026-07-29T10:01:00Z', status: 'Failed' },
+      ],
+      status: 'Failed',
+    };
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => HttpResponse.json(failedRun))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByText(/warehouse offline/)).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/client/src/test/components/dataImport/DataImportStage.test.tsx
+++ b/client/src/test/components/dataImport/DataImportStage.test.tsx
@@ -117,6 +117,61 @@ describe('Data Import stage', () => {
     }
   });
 
+  it('shows an error with retry when the import run cannot be loaded', async () => {
+    let requests = 0;
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => {
+        requests += 1;
+        return requests > 1
+          ? HttpResponse.json(succeededRun)
+          : new HttpResponse(null, { status: 500 });
+      })
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(
+        await screen.findByRole('heading', { name: 'Unable to load import status' })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('No import has run yet for this cycle.')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /start import/i })
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+      expect(await screen.findByText('AE transactions')).toBeInTheDocument();
+      expect(requests).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows the server explanation when starting the import fails', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => new HttpResponse(null, { status: 204 })),
+      http.post(
+        '/api/importruns',
+        () =>
+          new HttpResponse('An import run is already in progress.', {
+            status: 409,
+          })
+      )
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      fireEvent.click(await screen.findByRole('button', { name: /start import/i }));
+      expect(
+        await screen.findByText('An import run is already in progress.')
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('surfaces stage errors', async () => {
     const failedRun = {
       ...succeededRun,

--- a/client/src/test/components/dataImport/importRuns.test.ts
+++ b/client/src/test/components/dataImport/importRuns.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { bufferedImportWindow } from '@/queries/importRuns.ts';
+
+describe('bufferedImportWindow', () => {
+  it('extends the cycle by 3 months on each end', () => {
+    expect(bufferedImportWindow('2025-10-01', '2026-09-30')).toEqual({
+      windowEnd: '2026-12-30',
+      windowStart: '2025-07-01',
+    });
+  });
+
+  it('clamps to the last day of the target month like .NET AddMonths', () => {
+    expect(bufferedImportWindow('2025-11-30', '2025-11-30')).toEqual({
+      windowEnd: '2026-02-28',
+      windowStart: '2025-08-30',
+    });
+  });
+});

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -693,6 +693,9 @@ describe('AD419 workflow routes', () => {
       http.get('/api/user/me', () => {
         return HttpResponse.json(mockUser);
       }),
+      http.get('/api/projectidentification/setup', () => {
+        return HttpResponse.json(setupResponse);
+      }),
       http.get('/api/importruns/current', () => {
         return new HttpResponse(null, { status: 204 });
       })

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -688,6 +688,26 @@ describe('AD419 workflow routes', () => {
     }
   });
 
+  it('lists the Data Import stage between Project Identification and Data Classification', async () => {
+    server.use(
+      http.get('/api/user/me', () => {
+        return HttpResponse.json(mockUser);
+      }),
+      http.get('/api/importruns/current', () => {
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(
+        await screen.findByRole('heading', { level: 1, name: 'Data Import' })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('loads any workflow stage directly without locking', async () => {
     server.use(
       http.get('/api/user/me', () => {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,5 +1,6 @@
 export type WorkflowStageId =
   | 'project-identification'
+  | 'data-import'
   | 'data-classification'
   | 'expense-review'
   | 'auto-associations'


### PR DESCRIPTION
Part 4 of 4 splitting #45 (#31): #49 database, #52 run/stage infrastructure, #50 pipeline, #51 UI. Stacked on #50; retarget after it merges.

- New Data Import workflow stage between Project Identification and Data Classification; the stepper becomes seven steps on one row.
- The page shows the confirmed fiscal period read-only (the server owns the cycle dates), the buffered import window with the wide-net explanation, and per-stage progress with row counts that double as a QA check against prior year expectations. Errors surface per stage.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)