### PR TITLE
Expense import: run and stage infrastructure

### DIFF
--- a/server.core/Data/AppDbContext.cs
+++ b/server.core/Data/AppDbContext.cs
@@ -12,6 +12,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<User> Users => Set<User>();
     public DbSet<WorkflowRun> WorkflowRuns => Set<WorkflowRun>();
     public DbSet<WorkflowChecklistItemState> WorkflowChecklistItemStates => Set<WorkflowChecklistItemState>();
+    public DbSet<ImportRun> ImportRuns => Set<ImportRun>();
+    public DbSet<ImportRunStage> ImportRunStages => Set<ImportRunStage>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -22,6 +24,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<User>().ToTable("Users", AppSchema);
         modelBuilder.Entity<WorkflowRun>().ToTable("WorkflowRun", AppSchema);
         modelBuilder.Entity<WorkflowChecklistItemState>().ToTable("WorkflowChecklistItemState", AppSchema);
+        modelBuilder.Entity<ImportRun>().ToTable("ImportRun", AppSchema);
+        modelBuilder.Entity<ImportRunStage>().ToTable("ImportRunStage", AppSchema);
 
         modelBuilder.Entity<WorkflowRun>()
             .HasIndex(run => run.IsCurrent)
@@ -39,5 +43,14 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .WithMany()
             .HasForeignKey(state => state.SourceImportLogId)
             .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ImportRun>()
+            .HasMany(run => run.Stages)
+            .WithOne(stage => stage.ImportRun)
+            .HasForeignKey(stage => stage.ImportRunId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<ImportRun>()
+            .HasIndex(run => run.Status);
     }
 }

--- a/server.core/Data/DbInitializer.cs
+++ b/server.core/Data/DbInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Server.Core.Data;
+using Server.Core.Import;
 
 public interface IDbInitializer
 {
@@ -25,6 +26,8 @@ public class DbInitializer : IDbInitializer
         _logger.LogInformation("Applying database migrations...");
         await _db.Database.MigrateAsync(cancellationToken);
         _logger.LogInformation("Migrations applied.");
+
+        await ImportRunOrchestrator.FailInterruptedRunsAsync(_db, cancellationToken);
 
         if (includeDevSeed)
         {

--- a/server.core/Domain/ImportRun.cs
+++ b/server.core/Domain/ImportRun.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Server.Core.Domain;
+
+public static class ImportRunStatus
+{
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string Failed = "Failed";
+}
+
+public class ImportRun
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public DateOnly CycleStart { get; set; }
+
+    public DateOnly CycleEnd { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string Status { get; set; } = string.Empty;
+
+    public Guid? TriggeredByEntraId { get; set; }
+
+    [MaxLength(200)]
+    public string? TriggeredByName { get; set; }
+
+    [MaxLength(320)]
+    public string? TriggeredByEmail { get; set; }
+
+    public DateTimeOffset StartedAt { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    public List<ImportRunStage> Stages { get; set; } = [];
+}

--- a/server.core/Domain/ImportRunStage.cs
+++ b/server.core/Domain/ImportRunStage.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Server.Core.Domain;
+
+public static class ImportStageStatus
+{
+    public const string Pending = "Pending";
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string Failed = "Failed";
+}
+
+public class ImportRunStage
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int ImportRunId { get; set; }
+
+    public ImportRun? ImportRun { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    public int Ordinal { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string Status { get; set; } = string.Empty;
+
+    public int? RowCount { get; set; }
+
+    // Optional human-readable summary shown instead of the raw row count,
+    // e.g. "479 AE projects, 364 NIFA projects" for the build projects stage.
+    [MaxLength(200)]
+    public string? Detail { get; set; }
+
+    public DateTimeOffset? StartedAt { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    public string? ErrorDetail { get; set; }
+}

--- a/server.core/Import/ImportRunOrchestrator.cs
+++ b/server.core/Import/ImportRunOrchestrator.cs
@@ -1,0 +1,89 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+using Server.Core.Domain;
+
+namespace Server.Core.Import;
+
+public sealed class ImportRunOrchestrator
+{
+    private readonly AppDbContext _appDb;
+    private readonly IImportStageProvider _stageProvider;
+    private readonly ILogger<ImportRunOrchestrator> _logger;
+
+    public ImportRunOrchestrator(
+        AppDbContext appDb,
+        IImportStageProvider stageProvider,
+        ILogger<ImportRunOrchestrator> logger)
+    {
+        _appDb = appDb;
+        _stageProvider = stageProvider;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(int runId, CancellationToken cancellationToken = default)
+    {
+        var run = await _appDb.ImportRuns
+            .Include(r => r.Stages)
+            .SingleAsync(r => r.Id == runId, cancellationToken);
+
+        var context = new ImportRunContext(run.Id, run.CycleStart, run.CycleEnd);
+        var stagesByName = run.Stages.ToDictionary(s => s.Name);
+
+        foreach (var stage in _stageProvider.BuildStages(context))
+        {
+            var record = stagesByName[stage.Name];
+            record.Status = ImportStageStatus.Running;
+            record.StartedAt = DateTimeOffset.UtcNow;
+            await _appDb.SaveChangesAsync(cancellationToken);
+
+            try
+            {
+                var result = await stage.ExecuteAsync(cancellationToken);
+                record.RowCount = result.RowCount;
+                record.Detail = result.Detail;
+                record.Status = ImportStageStatus.Succeeded;
+                record.CompletedAt = DateTimeOffset.UtcNow;
+                await _appDb.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Import stage {Stage} failed for run {RunId}", stage.Name, runId);
+                record.Status = ImportStageStatus.Failed;
+                record.ErrorDetail = ex.ToString();
+                record.CompletedAt = DateTimeOffset.UtcNow;
+                run.Status = ImportRunStatus.Failed;
+                run.CompletedAt = DateTimeOffset.UtcNow;
+                await _appDb.SaveChangesAsync(CancellationToken.None);
+                return;
+            }
+        }
+
+        run.Status = ImportRunStatus.Succeeded;
+        run.CompletedAt = DateTimeOffset.UtcNow;
+        await _appDb.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task FailInterruptedRunsAsync(AppDbContext appDb, CancellationToken cancellationToken = default)
+    {
+        var interrupted = await appDb.ImportRuns
+            .Include(r => r.Stages)
+            .Where(r => r.Status == ImportRunStatus.Running)
+            .ToListAsync(cancellationToken);
+
+        foreach (var run in interrupted)
+        {
+            run.Status = ImportRunStatus.Failed;
+            run.CompletedAt = DateTimeOffset.UtcNow;
+
+            foreach (var stage in run.Stages.Where(s => s.Status == ImportStageStatus.Running))
+            {
+                stage.Status = ImportStageStatus.Failed;
+                stage.ErrorDetail = "Interrupted by application restart.";
+                stage.CompletedAt = DateTimeOffset.UtcNow;
+            }
+        }
+
+        await appDb.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/server.core/Import/ImportStage.cs
+++ b/server.core/Import/ImportStage.cs
@@ -1,0 +1,46 @@
+namespace Server.Core.Import;
+
+public sealed record ImportRunContext(int RunId, DateOnly CycleStart, DateOnly CycleEnd);
+
+public sealed record ImportStageResult(int RowCount, string? Detail = null);
+
+public sealed record ImportStage(string Name, Func<CancellationToken, Task<ImportStageResult>> ExecuteAsync)
+{
+    /// <summary>Adapts a stage that reports only a row count.</summary>
+    public static ImportStage FromRowCount(string name, Func<CancellationToken, Task<int>> executeAsync) =>
+        new(name, async ct => new ImportStageResult(await executeAsync(ct)));
+}
+
+public interface IImportStageProvider
+{
+    IReadOnlyList<string> StageNames { get; }
+
+    IReadOnlyList<ImportStage> BuildStages(ImportRunContext context);
+}
+
+public static class ImportStageNames
+{
+    public const string ChartSegmentsPrefix = "ChartSegments: ";
+    public const string BuildProjects = "Build projects";
+    public const string AeTransactions = "AE transactions";
+    public const string UcPathTransactions = "UCPath transactions";
+    public const string SeedSegmentClassifications = "Seed segment classifications";
+    public const string ClassifyTransactions = "Classify transactions";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        ChartSegmentsPrefix + "Entity",
+        ChartSegmentsPrefix + "Fund",
+        ChartSegmentsPrefix + "Financial Department",
+        ChartSegmentsPrefix + "Account",
+        ChartSegmentsPrefix + "Purpose",
+        ChartSegmentsPrefix + "Program",
+        ChartSegmentsPrefix + "Project",
+        ChartSegmentsPrefix + "Activity",
+        BuildProjects,
+        AeTransactions,
+        UcPathTransactions,
+        SeedSegmentClassifications,
+        ClassifyTransactions,
+    ];
+}

--- a/server.core/Migrations/20260729172616_AddImportRuns.Designer.cs
+++ b/server.core/Migrations/20260729172616_AddImportRuns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Server.Core.Data;
 
@@ -11,9 +12,11 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729172616_AddImportRuns")]
+    partial class AddImportRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -133,10 +136,6 @@ namespace server.core.Migrations
 
                     b.Property<DateTimeOffset?>("CompletedAt")
                         .HasColumnType("datetimeoffset");
-
-                    b.Property<string>("Detail")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("ErrorDetail")
                         .HasColumnType("nvarchar(max)");

--- a/server.core/Migrations/20260729172616_AddImportRuns.cs
+++ b/server.core/Migrations/20260729172616_AddImportRuns.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImportRun",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CycleStart = table.Column<DateOnly>(type: "date", nullable: false),
+                    CycleEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    TriggeredByEntraId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    TriggeredByName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    TriggeredByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true),
+                    StartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportRun", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImportRunStage",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ImportRunId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Ordinal = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    RowCount = table.Column<int>(type: "int", nullable: true),
+                    StartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    ErrorDetail = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportRunStage", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ImportRunStage_ImportRun_ImportRunId",
+                        column: x => x.ImportRunId,
+                        principalSchema: "app",
+                        principalTable: "ImportRun",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportRun_Status",
+                schema: "app",
+                table: "ImportRun",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportRunStage_ImportRunId",
+                schema: "app",
+                table: "ImportRunStage",
+                column: "ImportRunId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImportRunStage",
+                schema: "app");
+
+            migrationBuilder.DropTable(
+                name: "ImportRun",
+                schema: "app");
+        }
+    }
+}

--- a/server.core/Migrations/20260730174853_AddImportRunStageDetail.Designer.cs
+++ b/server.core/Migrations/20260730174853_AddImportRunStageDetail.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Server.Core.Data;
 
@@ -11,9 +12,11 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730174853_AddImportRunStageDetail")]
+    partial class AddImportRunStageDetail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server.core/Migrations/20260730174853_AddImportRunStageDetail.cs
+++ b/server.core/Migrations/20260730174853_AddImportRunStageDetail.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportRunStageDetail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Detail",
+                schema: "app",
+                table: "ImportRunStage",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Detail",
+                schema: "app",
+                table: "ImportRunStage");
+        }
+    }
+}

--- a/tests/server.tests/Import/ImportRunEntityTests.cs
+++ b/tests/server.tests/Import/ImportRunEntityTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Server.Core.Domain;
+
+namespace Server.Tests.Import;
+
+public class ImportRunEntityTests
+{
+    [Fact]
+    public async Task ImportRun_round_trips_with_stages()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+
+        var run = new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages =
+            {
+                new ImportRunStage { Name = "ChartSegments: Fund", Ordinal = 2, Status = ImportStageStatus.Pending },
+            },
+        };
+
+        db.ImportRuns.Add(run);
+        await db.SaveChangesAsync();
+
+        var loaded = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        loaded.Stages.Should().ContainSingle(s => s.Name == "ChartSegments: Fund" && s.Status == "Pending");
+        loaded.Status.Should().Be("Running");
+    }
+}

--- a/tests/server.tests/Import/ImportRunOrchestratorTests.cs
+++ b/tests/server.tests/Import/ImportRunOrchestratorTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportRunOrchestratorTests
+{
+    private sealed class FakeStageProvider(params ImportStage[] stages) : IImportStageProvider
+    {
+        public IReadOnlyList<string> StageNames { get; } = stages.Select(s => s.Name).ToList();
+        public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context) => stages;
+    }
+
+    private static async Task<int> SeedRunAsync(AppDbContext db, IImportStageProvider provider)
+    {
+        var run = new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages = provider.StageNames
+                .Select((name, i) => new ImportRunStage { Name = name, Ordinal = i, Status = ImportStageStatus.Pending })
+                .ToList(),
+        };
+        db.ImportRuns.Add(run);
+        await db.SaveChangesAsync();
+        return run.Id;
+    }
+
+    [Fact]
+    public async Task Runs_stages_in_order_and_records_row_counts()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var order = new List<string>();
+        var provider = new FakeStageProvider(
+            ImportStage.FromRowCount("one", _ => { order.Add("one"); return Task.FromResult(5); }),
+            new ImportStage("two", _ =>
+            {
+                order.Add("two");
+                return Task.FromResult(new ImportStageResult(7, "7 AE projects, 3 NIFA projects"));
+            }));
+        var runId = await SeedRunAsync(db, provider);
+
+        await new ImportRunOrchestrator(db, provider, NullLogger<ImportRunOrchestrator>.Instance).RunAsync(runId);
+
+        order.Should().Equal("one", "two");
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Succeeded);
+        run.CompletedAt.Should().NotBeNull();
+        run.Stages.Should().OnlyContain(s => s.Status == ImportStageStatus.Succeeded);
+        run.Stages.Single(s => s.Name == "one").RowCount.Should().Be(5);
+        run.Stages.Single(s => s.Name == "one").Detail.Should().BeNull();
+        run.Stages.Single(s => s.Name == "two").RowCount.Should().Be(7);
+        run.Stages.Single(s => s.Name == "two").Detail.Should().Be("7 AE projects, 3 NIFA projects");
+    }
+
+    [Fact]
+    public async Task Failing_stage_stops_the_run_and_leaves_later_stages_pending()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var provider = new FakeStageProvider(
+            ImportStage.FromRowCount("one", _ => Task.FromResult(1)),
+            ImportStage.FromRowCount("boom", _ => throw new InvalidOperationException("warehouse offline")),
+            ImportStage.FromRowCount("three", _ => Task.FromResult(3)));
+        var runId = await SeedRunAsync(db, provider);
+
+        await new ImportRunOrchestrator(db, provider, NullLogger<ImportRunOrchestrator>.Instance).RunAsync(runId);
+
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Failed);
+        run.Stages.Single(s => s.Name == "one").Status.Should().Be(ImportStageStatus.Succeeded);
+        var failed = run.Stages.Single(s => s.Name == "boom");
+        failed.Status.Should().Be(ImportStageStatus.Failed);
+        failed.ErrorDetail.Should().Contain("warehouse offline");
+        run.Stages.Single(s => s.Name == "three").Status.Should().Be(ImportStageStatus.Pending);
+    }
+
+    [Fact]
+    public async Task Startup_sweep_marks_running_runs_failed()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        db.ImportRuns.Add(new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages =
+            {
+                new ImportRunStage { Name = "one", Ordinal = 0, Status = ImportStageStatus.Succeeded },
+                new ImportRunStage { Name = "two", Ordinal = 1, Status = ImportStageStatus.Running },
+                new ImportRunStage { Name = "three", Ordinal = 2, Status = ImportStageStatus.Pending },
+            },
+        });
+        await db.SaveChangesAsync();
+
+        await ImportRunOrchestrator.FailInterruptedRunsAsync(db);
+
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Failed);
+        run.Stages.Single(s => s.Name == "two").Status.Should().Be(ImportStageStatus.Failed);
+        run.Stages.Single(s => s.Name == "two").ErrorDetail.Should().Be("Interrupted by application restart.");
+        run.Stages.Single(s => s.Name == "one").Status.Should().Be(ImportStageStatus.Succeeded);
+        run.Stages.Single(s => s.Name == "three").Status.Should().Be(ImportStageStatus.Pending);
+    }
+}


### PR DESCRIPTION
Part of the #45 split (#31), stacked on #49. The generic machinery for background import runs, with no domain logic and no DI wiring:

- ImportRun and ImportRunStage entities in the app schema with their EF migrations: per run cycle dates, status, triggered-by, timestamps; per stage name, ordinal, status, row count, optional detail string, and error detail.
- ImportStage / ImportStageResult / IImportStageProvider abstractions and the fail-stop ImportRunOrchestrator: stages run in order, each recording status and row counts; the first failure stops the run and leaves later stages pending.
- A startup sweep marks runs interrupted by an application restart as failed.

Nothing registers in DI here, so this is inert until the pipeline PR composes stages onto it. That PR (the business piece) follows; the frontend PR is #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)