### PR TITLE
Expense import: database, pipeline, and Data Import stage

### DIFF
--- a/client/src/components/dataImport/DataImportStage.tsx
+++ b/client/src/components/dataImport/DataImportStage.tsx
@@ -1,0 +1,219 @@
+import { SectionPanel } from '@/components/SectionPanel.tsx';
+import {
+  bufferedImportWindow,
+  importRunQueryOptions,
+  startImportRun,
+} from '@/queries/importRuns.ts';
+import {
+  projectIdentificationSetupQueryOptions,
+  type ProjectIdentificationSetupResponse,
+} from '@/queries/projectIdentification.ts';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { ImportRunStage } from '@/queries/importRuns.ts';
+
+const STATUS_BADGES: Record<ImportRunStage['status'], string> = {
+  Failed: 'badge badge-error badge-outline',
+  Pending: 'badge badge-ghost',
+  Running: 'badge badge-info',
+  Succeeded: 'badge badge-success badge-outline',
+};
+
+export function DataImportStage() {
+  const setupQuery = useQuery(projectIdentificationSetupQueryOptions());
+
+  if (setupQuery.isLoading) {
+    return <p>Loading data import...</p>;
+  }
+
+  if (setupQuery.isError || !setupQuery.data) {
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load reporting cycle</h2>
+          <p>
+            The fiscal period from Project Identification could not be loaded.
+          </p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={setupQuery.isFetching}
+            onClick={() => void setupQuery.refetch()}
+            type="button"
+          >
+            {setupQuery.isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return <DataImportStageContent setup={setupQuery.data} />;
+}
+
+function DataImportStageContent({
+  setup,
+}: {
+  setup: ProjectIdentificationSetupResponse;
+}) {
+  const queryClient = useQueryClient();
+  const { data: run } = useQuery(importRunQueryOptions());
+
+  const start = useMutation({
+    mutationFn: startImportRun,
+    onSuccess: (created) => {
+      queryClient.setQueryData(importRunQueryOptions().queryKey, created);
+    },
+  });
+
+  const periodLabel =
+    setup.fiscalPeriodOptions.find(
+      (option) => option.fiscalYear === setup.fiscalYear
+    )?.label ?? '';
+  const { windowEnd, windowStart } = bufferedImportWindow(
+    setup.cycleStart,
+    setup.cycleEnd
+  );
+
+  const isRunning = run?.status === 'Running' || start.isPending;
+  const failedStages =
+    run?.stages.filter((stage) => stage.status === 'Failed') ?? [];
+  const sortedStages = [...(run?.stages ?? [])].sort(
+    (a, b) => a.ordinal - b.ordinal
+  );
+
+  return (
+    <SectionPanel eyebrow="Expense Data" title="Data Import">
+      <div className="space-y-4 p-4">
+        <p className="text-sm text-slate-600">
+          Pulls AE and UCPath transactions for the reporting cycle and seeds
+          new chart string segments for classification. The fiscal year comes
+          from the Project Identification step. Pulling in transactions may
+          take several hours, and the import keeps running in the background
+          if you leave this page.
+        </p>
+
+        <p className="text-sm text-slate-600">
+          Transactions are imported for {formatDate(windowStart)} through{' '}
+          {formatDate(windowEnd)}, the fiscal year with a 3 month buffer on
+          each end. We intentionally cast a wide net to make sure we&apos;re
+          pulling in all relevant transactions. Transactions from outside the
+          fiscal year will be excluded for the final report.
+        </p>
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <label className="form-control w-full">
+            <span className="label-text">Fiscal year</span>
+            <select
+              className="select select-bordered w-full"
+              disabled
+              value={setup.fiscalYear}
+            >
+              <option value={setup.fiscalYear}>
+                {setup.fiscalYear.replace('FY', 'FY:')}
+              </option>
+            </select>
+          </label>
+
+          <label className="form-control w-full">
+            <span className="label-text">Period</span>
+            <select
+              className="select select-bordered w-full"
+              disabled
+              value={periodLabel}
+            >
+              <option>{periodLabel}</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            className="btn btn-primary"
+            disabled={isRunning}
+            onClick={() => start.mutate()}
+            type="button"
+          >
+            Start Import
+          </button>
+        </div>
+
+        {start.error ? (
+          <div className="alert alert-error" role="alert">
+            <span>
+              {start.error instanceof Error
+                ? start.error.message
+                : 'Failed to start the import.'}
+            </span>
+          </div>
+        ) : null}
+
+        {failedStages.map((stage) => (
+          <div className="alert alert-error" key={stage.ordinal} role="alert">
+            <span>
+              {stage.name}: {stage.errorDetail}
+            </span>
+          </div>
+        ))}
+
+        {run ? (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+              <span className={STATUS_BADGES[run.status]}>{run.status}</span>
+              <span>
+                Cycle {formatDate(run.cycleStart)} through{' '}
+                {formatDate(run.cycleEnd)}
+              </span>
+              {run.triggeredByName ? (
+                <span>Triggered by {run.triggeredByName}</span>
+              ) : null}
+              <span>Started {formatDateTime(run.startedAt)}</span>
+              {run.completedAt ? (
+                <span>Completed {formatDateTime(run.completedAt)}</span>
+              ) : null}
+            </div>
+
+            <table className="table table-zebra table-sm">
+              <thead>
+                <tr>
+                  <th>Stage</th>
+                  <th>Status</th>
+                  <th>Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedStages.map((stage) => (
+                  <tr key={stage.ordinal}>
+                    <td>{stage.name}</td>
+                    <td>
+                      <span className={STATUS_BADGES[stage.status]}>
+                        {stage.status}
+                      </span>
+                    </td>
+                    <td>{stage.detail ?? stage.rowCount?.toLocaleString() ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="rounded border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-slate-600">
+            No import has run yet for this cycle.
+          </div>
+        )}
+      </div>
+    </SectionPanel>
+  );
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}

--- a/client/src/components/dataImport/DataImportStage.tsx
+++ b/client/src/components/dataImport/DataImportStage.tsx
@@ -1,3 +1,4 @@
+import { HttpError } from '@/lib/api.ts';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
 import {
   bufferedImportWindow,
@@ -55,7 +56,8 @@ function DataImportStageContent({
   setup: ProjectIdentificationSetupResponse;
 }) {
   const queryClient = useQueryClient();
-  const { data: run } = useQuery(importRunQueryOptions());
+  const runQuery = useQuery(importRunQueryOptions());
+  const run = runQuery.data;
 
   const start = useMutation({
     mutationFn: startImportRun,
@@ -63,6 +65,29 @@ function DataImportStageContent({
       queryClient.setQueryData(importRunQueryOptions().queryKey, created);
     },
   });
+
+  if (runQuery.isLoading) {
+    return <p>Loading data import...</p>;
+  }
+
+  if (runQuery.isError) {
+    return (
+      <div className="alert alert-error items-start" role="alert">
+        <div>
+          <h2 className="font-bold">Unable to load import status</h2>
+          <p>The current import run could not be loaded.</p>
+          <button
+            className="btn btn-sm mt-3"
+            disabled={runQuery.isFetching}
+            onClick={() => void runQuery.refetch()}
+            type="button"
+          >
+            {runQuery.isFetching ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const periodLabel =
     setup.fiscalPeriodOptions.find(
@@ -138,11 +163,7 @@ function DataImportStageContent({
 
         {start.error ? (
           <div className="alert alert-error" role="alert">
-            <span>
-              {start.error instanceof Error
-                ? start.error.message
-                : 'Failed to start the import.'}
-            </span>
+            <span>{startErrorMessage(start.error)}</span>
           </div>
         ) : null}
 
@@ -202,6 +223,28 @@ function DataImportStageContent({
       </div>
     </SectionPanel>
   );
+}
+
+// The server explains start rejections (no confirmed period, run already in
+// progress, readiness issues) as a plain-string Conflict body.
+function startErrorMessage(error: unknown) {
+  if (error instanceof HttpError) {
+    if (typeof error.body === 'string' && error.body.trim()) {
+      return error.body;
+    }
+
+    if (
+      error.body &&
+      typeof error.body === 'object' &&
+      'message' in error.body &&
+      typeof error.body.message === 'string' &&
+      error.body.message.trim()
+    ) {
+      return error.body.message;
+    }
+  }
+
+  return 'Failed to start the import.';
 }
 
 function formatDate(value: string) {

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -28,7 +28,7 @@
   }
 
   .workflow-stepper {
-    @apply grid border-b border-slate-200 bg-white px-4 shadow-sm lg:grid-cols-6 lg:px-8;
+    @apply grid border-b border-slate-200 bg-white px-4 shadow-sm lg:grid-cols-7 lg:px-8;
   }
 
   .workflow-step {

--- a/client/src/mockData.ts
+++ b/client/src/mockData.ts
@@ -14,37 +14,44 @@ export const workflowStages: WorkflowStage[] = [
   },
   {
     description:
+      'Pull AE and UCPath transactions for the cycle and seed new chart-string segments for classification.',
+    id: 'data-import',
+    number: 2,
+    title: 'Data Import',
+  },
+  {
+    description:
       'Classify new chart-string segments before they can be included in the AD419 report.',
     id: 'data-classification',
-    number: 2,
+    number: 3,
     title: 'Data Classification',
   },
   {
     description:
       'Confirm the right transactions are included before triggering auto-associations.',
     id: 'expense-review',
-    number: 3,
+    number: 4,
     title: 'Expense Review',
   },
   {
     description:
       'Run the rules engine to associate as many expenses as possible before manual review.',
     id: 'auto-associations',
-    number: 4,
+    number: 5,
     title: 'Auto-Associations',
   },
   {
     description:
       'Resolve flagged items after manual associations are complete.',
     id: 'post-association-review',
-    number: 5,
+    number: 6,
     title: 'Post-Association Review',
   },
   {
     description:
       'Generate the final files for ANR submission and cycle signoff.',
     id: 'final-reports',
-    number: 6,
+    number: 7,
     title: 'Final Reports',
   },
 ];

--- a/client/src/queries/importRuns.ts
+++ b/client/src/queries/importRuns.ts
@@ -51,16 +51,11 @@ const IMPORT_RUN_KEY = ['importRun'] as const;
 
 export const importRunQueryOptions = () =>
   queryOptions({
-    queryFn: async ({ signal }): Promise<ImportRun | null> => {
-      const response = await fetch('/api/importruns/current', { signal });
-      if (response.status === 204) {
-        return null;
-      }
-      if (!response.ok) {
-        throw new Error(`Failed to load import run (${response.status})`);
-      }
-      return (await response.json()) as ImportRun;
-    },
+    // fetchJson resolves undefined for the 204 "no run yet" response; the
+    // query needs null so react-query treats it as data, not a missing value.
+    queryFn: async ({ signal }): Promise<ImportRun | null> =>
+      (await fetchJson<ImportRun | null>('/api/importruns/current', {}, signal)) ??
+      null,
     queryKey: IMPORT_RUN_KEY,
     refetchInterval: (query) =>
       query.state.data?.status === 'Running' ? 2000 : false,

--- a/client/src/queries/importRuns.ts
+++ b/client/src/queries/importRuns.ts
@@ -1,0 +1,75 @@
+import { fetchJson } from '@/lib/api.ts';
+import { queryOptions } from '@tanstack/react-query';
+
+export interface ImportRunStage {
+  completedAt: string | null;
+  detail: string | null;
+  errorDetail: string | null;
+  name: string;
+  ordinal: number;
+  rowCount: number | null;
+  startedAt: string | null;
+  status: 'Failed' | 'Pending' | 'Running' | 'Succeeded';
+}
+
+export interface ImportRun {
+  completedAt: string | null;
+  cycleEnd: string;
+  cycleStart: string;
+  id: number;
+  stages: ImportRunStage[];
+  startedAt: string;
+  status: 'Failed' | 'Running' | 'Succeeded';
+  triggeredByName: string | null;
+}
+
+// Mirrors ImportSql.BufferedWindow on the server: months clamp to the last
+// day of the target month, matching .NET AddMonths.
+export function bufferedImportWindow(
+  cycleStart: string,
+  cycleEnd: string
+): { windowEnd: string; windowStart: string } {
+  return {
+    windowEnd: addMonths(cycleEnd, 3),
+    windowStart: addMonths(cycleStart, -3),
+  };
+}
+
+function addMonths(isoDate: string, months: number): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  const totalMonths = year * 12 + (month - 1) + months;
+  const targetYear = Math.floor(totalMonths / 12);
+  const targetMonth = (totalMonths % 12) + 1;
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth, 0)).getUTCDate();
+  const targetDay = Math.min(day, lastDay);
+  return `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(
+    targetDay
+  ).padStart(2, '0')}`;
+}
+
+const IMPORT_RUN_KEY = ['importRun'] as const;
+
+export const importRunQueryOptions = () =>
+  queryOptions({
+    queryFn: async ({ signal }): Promise<ImportRun | null> => {
+      const response = await fetch('/api/importruns/current', { signal });
+      if (response.status === 204) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to load import run (${response.status})`);
+      }
+      return (await response.json()) as ImportRun;
+    },
+    queryKey: IMPORT_RUN_KEY,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'Running' ? 2000 : false,
+  });
+
+// The server takes the cycle from the confirmed fiscal period; the client
+// sends no dates so a stale tab can never import the wrong year.
+export function startImportRun(): Promise<ImportRun> {
+  return fetchJson<ImportRun>('/api/importruns', {
+    method: 'POST',
+  });
+}

--- a/client/src/routes/(authenticated)/workflow.$stageId.tsx
+++ b/client/src/routes/(authenticated)/workflow.$stageId.tsx
@@ -4,6 +4,7 @@ import {
 } from '@/mockData.ts';
 import { workflowSnapshotQueryOptions } from '@/queries.ts';
 import { DataClassificationStage } from '@/components/dataClassification/DataClassificationStage.tsx';
+import { DataImportStage } from '@/components/dataImport/DataImportStage.tsx';
 import { ProjectIdentificationStage } from '@/components/ProjectIdentificationStage.tsx';
 import { SectionPanel } from '@/components/SectionPanel.tsx';
 import { WorkflowShell } from '@/components/WorkflowShell.tsx';
@@ -51,6 +52,8 @@ function WorkflowStageRoute() {
           <ProjectIdentificationStage />
         ) : workflowStageId === 'data-classification' ? (
           <DataClassificationStage />
+        ) : workflowStageId === 'data-import' ? (
+          <DataImportStage />
         ) : (
           <SectionPanel title="Coming soon">
             <p>This step is coming soon.</p>

--- a/client/src/test/components/dataImport/DataImportStage.test.tsx
+++ b/client/src/test/components/dataImport/DataImportStage.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+
+const mockUser = {
+  email: 'shannon@example.edu',
+  id: 'user-1',
+  name: 'Shannon Taylor',
+  roles: ['User'],
+};
+
+const setupResponse = {
+  checklistItems: [],
+  completedCount: 7,
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  fiscalPeriodOptions: [
+    {
+      cycleEnd: '2026-09-30',
+      cycleStart: '2025-10-01',
+      fiscalYear: 'FY26',
+      label: 'FY:26 - Oct 2025 - Sep 2026',
+    },
+  ],
+  fiscalYear: 'FY26',
+  totalCount: 7,
+  workflowRunId: 1,
+};
+
+const succeededRun = {
+  completedAt: '2026-07-29T10:05:00Z',
+  cycleEnd: '2026-09-30',
+  cycleStart: '2025-10-01',
+  id: 1,
+  stages: [
+    { completedAt: '2026-07-29T10:01:00Z', detail: null, errorDetail: null, name: 'ChartSegments: Fund', ordinal: 1, rowCount: 1200, startedAt: '2026-07-29T10:00:00Z', status: 'Succeeded' },
+    { completedAt: '2026-07-29T10:02:00Z', detail: '479 AE projects, 364 NIFA projects', errorDetail: null, name: 'Build projects', ordinal: 8, rowCount: 479, startedAt: '2026-07-29T10:01:00Z', status: 'Succeeded' },
+    { completedAt: '2026-07-29T10:05:00Z', detail: null, errorDetail: null, name: 'AE transactions', ordinal: 9, rowCount: 413_637, startedAt: '2026-07-29T10:02:00Z', status: 'Succeeded' },
+  ],
+  startedAt: '2026-07-29T10:00:00Z',
+  status: 'Succeeded',
+  triggeredByName: 'Rob',
+};
+
+function useSetupHandler() {
+  server.use(
+    http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+    http.get('/api/projectidentification/setup', () =>
+      HttpResponse.json(setupResponse)
+    )
+  );
+}
+
+describe('Data Import stage', () => {
+  it('shows the fiscal period from project identification with the buffered window', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => new HttpResponse(null, { status: 204 }))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByDisplayValue('FY:26')).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('FY:26 - Oct 2025 - Sep 2026')
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Jul 1, 2025/)).toBeInTheDocument();
+      expect(screen.getByText(/Dec 30, 2026/)).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows the latest run with per-stage row counts', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => HttpResponse.json(succeededRun))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByText('AE transactions')).toBeInTheDocument();
+      expect(screen.getByText('413,637')).toBeInTheDocument();
+      expect(
+        screen.getByText('479 AE projects, 364 NIFA projects')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /start import/i })).toBeEnabled();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('starts an import without posting dates and disables the button while running', async () => {
+    let started = false;
+    let postedBody: string | null = null;
+    const runningRun = { ...succeededRun, completedAt: null, id: 2, status: 'Running' };
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () =>
+        started ? HttpResponse.json(runningRun) : new HttpResponse(null, { status: 204 })
+      ),
+      http.post('/api/importruns', async ({ request }) => {
+        started = true;
+        postedBody = await request.text();
+        return HttpResponse.json(runningRun);
+      })
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      const start = await screen.findByRole('button', { name: /start import/i });
+      fireEvent.click(start);
+      await waitFor(() => expect(screen.getByRole('button', { name: /start import/i })).toBeDisabled());
+      // the server sources the cycle from the confirmed fiscal period
+      expect(postedBody).toBe('');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('surfaces stage errors', async () => {
+    const failedRun = {
+      ...succeededRun,
+      id: 3,
+      stages: [
+        { completedAt: '2026-07-29T10:02:00Z', detail: null, errorDetail: 'warehouse offline', name: 'AE transactions', ordinal: 9, rowCount: null, startedAt: '2026-07-29T10:01:00Z', status: 'Failed' },
+      ],
+      status: 'Failed',
+    };
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => HttpResponse.json(failedRun))
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(await screen.findByText(/warehouse offline/)).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/client/src/test/components/dataImport/DataImportStage.test.tsx
+++ b/client/src/test/components/dataImport/DataImportStage.test.tsx
@@ -117,6 +117,61 @@ describe('Data Import stage', () => {
     }
   });
 
+  it('shows an error with retry when the import run cannot be loaded', async () => {
+    let requests = 0;
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => {
+        requests += 1;
+        return requests > 1
+          ? HttpResponse.json(succeededRun)
+          : new HttpResponse(null, { status: 500 });
+      })
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(
+        await screen.findByRole('heading', { name: 'Unable to load import status' })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('No import has run yet for this cycle.')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /start import/i })
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+      expect(await screen.findByText('AE transactions')).toBeInTheDocument();
+      expect(requests).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows the server explanation when starting the import fails', async () => {
+    useSetupHandler();
+    server.use(
+      http.get('/api/importruns/current', () => new HttpResponse(null, { status: 204 })),
+      http.post(
+        '/api/importruns',
+        () =>
+          new HttpResponse('An import run is already in progress.', {
+            status: 409,
+          })
+      )
+    );
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      fireEvent.click(await screen.findByRole('button', { name: /start import/i }));
+      expect(
+        await screen.findByText('An import run is already in progress.')
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('surfaces stage errors', async () => {
     const failedRun = {
       ...succeededRun,

--- a/client/src/test/components/dataImport/importRuns.test.ts
+++ b/client/src/test/components/dataImport/importRuns.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { bufferedImportWindow } from '@/queries/importRuns.ts';
+
+describe('bufferedImportWindow', () => {
+  it('extends the cycle by 3 months on each end', () => {
+    expect(bufferedImportWindow('2025-10-01', '2026-09-30')).toEqual({
+      windowEnd: '2026-12-30',
+      windowStart: '2025-07-01',
+    });
+  });
+
+  it('clamps to the last day of the target month like .NET AddMonths', () => {
+    expect(bufferedImportWindow('2025-11-30', '2025-11-30')).toEqual({
+      windowEnd: '2026-02-28',
+      windowStart: '2025-08-30',
+    });
+  });
+});

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -693,6 +693,9 @@ describe('AD419 workflow routes', () => {
       http.get('/api/user/me', () => {
         return HttpResponse.json(mockUser);
       }),
+      http.get('/api/projectidentification/setup', () => {
+        return HttpResponse.json(setupResponse);
+      }),
       http.get('/api/importruns/current', () => {
         return new HttpResponse(null, { status: 204 });
       })

--- a/client/src/test/routes/(authenticated)/workflow.test.tsx
+++ b/client/src/test/routes/(authenticated)/workflow.test.tsx
@@ -688,6 +688,26 @@ describe('AD419 workflow routes', () => {
     }
   });
 
+  it('lists the Data Import stage between Project Identification and Data Classification', async () => {
+    server.use(
+      http.get('/api/user/me', () => {
+        return HttpResponse.json(mockUser);
+      }),
+      http.get('/api/importruns/current', () => {
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/workflow/data-import' });
+    try {
+      expect(
+        await screen.findByRole('heading', { level: 1, name: 'Data Import' })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('loads any workflow stage directly without locking', async () => {
     server.use(
       http.get('/api/user/me', () => {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,5 +1,6 @@
 export type WorkflowStageId =
   | 'project-identification'
+  | 'data-import'
   | 'data-classification'
   | 'expense-review'
   | 'auto-associations'

--- a/database/data/Functions/ImportBlockingIssueForCycle.sql
+++ b/database/data/Functions/ImportBlockingIssueForCycle.sql
@@ -1,0 +1,19 @@
+CREATE FUNCTION [data].[ImportBlockingIssueForCycle]
+(
+    @CycleStart DATE,
+    @CycleEnd DATE
+)
+RETURNS NVARCHAR(200)
+AS
+BEGIN
+    -- The reason an expense import cannot run for the given cycle, or NULL
+    -- when it can. The one definition shared by the import trigger endpoint
+    -- (rejects the run upfront) and the BuildProjects guard (fails closed if
+    -- a run reaches it anyway), so the two can never drift.
+    RETURN CASE
+        WHEN NOT EXISTS (SELECT 1 FROM [data].[ActiveProjects])
+            THEN N'ActiveProjects is empty; complete Project Identification before building the project list.'
+        WHEN EXISTS (SELECT 1 FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd) WHERE [Status] <> 'Clean')
+            THEN N'Unresolved project issues exist; resolve them in Project Identification first.'
+    END;
+END

--- a/database/data/StoredProcedures/BuildProjects.sql
+++ b/database/data/StoredProcedures/BuildProjects.sql
@@ -21,13 +21,11 @@ BEGIN
     -- project list; downstream consumers (expense views, associations) read
     -- this table instead of re-deriving the joins.
 
-    IF NOT EXISTS (SELECT 1 FROM [data].[ActiveProjects])
-        THROW 50000, 'ActiveProjects is empty; complete Project Identification before building the project list.', 1;
-
-    -- Fail closed on the same definition the Project Identification UI shows:
-    -- any non-Clean project means identification is not finished.
-    IF EXISTS (SELECT 1 FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd) WHERE [Status] <> 'Clean')
-        THROW 50000, 'Unresolved project issues exist; resolve them in Project Identification first.', 1;
+    -- Fail closed on the shared readiness definition (also used by the import
+    -- trigger endpoint, which normally rejects a not-ready run before it starts).
+    DECLARE @blockingIssue NVARCHAR(200) = [data].[ImportBlockingIssueForCycle](@CycleStart, @CycleEnd);
+    IF @blockingIssue IS NOT NULL
+        THROW 50000, @blockingIssue, 1;
 
     BEGIN TRAN;
 
@@ -72,6 +70,10 @@ BEGIN
 
     COMMIT;
 
-    -- Row count for the import run stage.
-    SELECT COUNT(*) AS ProjectRowsBuilt FROM [data].[Projects];
+    -- Counts for the import run stage: rows are NIFA x AE project pairs (204
+    -- awards fan out to many AE projects), so both grains are reported.
+    SELECT
+        COUNT(*) AS AeProjects,
+        COUNT(DISTINCT [AccessionNumber]) AS NifaProjects
+    FROM [data].[Projects];
 END

--- a/database/data/StoredProcedures/ClassifyTransactions.sql
+++ b/database/data/StoredProcedures/ClassifyTransactions.sql
@@ -62,6 +62,22 @@ BEGIN
     LEFT JOIN [data].[ChartSegments] cs
         ON cs.[SegmentName] = 'Account' AND cs.[Code] = t.[Account];
 
+    -- AccountInUcPath, AE: accounts that also appear in the UCPath pull. Those
+    -- dollars are reported from payroll detail, so the AE rows are excluded to
+    -- avoid double counting (2025 deleted them; a flag keeps them reviewable).
+    UPDATE t
+    SET [AccountInUcPath] =
+        CASE
+            WHEN t.[Account] IS NULL THEN 0
+            WHEN EXISTS
+            (
+                SELECT 1 FROM [data].[UcPathTransactions] u
+                WHERE u.[Account] = t.[Account]
+            ) THEN 1
+            ELSE 0
+        END
+    FROM [data].[AETransactions] t;
+
     -- Row counts for the import run stage.
     SELECT
         (SELECT COUNT(*) FROM [data].[AETransactions])     AS AeRowsClassified,

--- a/database/data/StoredProcedures/SeedSegmentClassifications.sql
+++ b/database/data/StoredProcedures/SeedSegmentClassifications.sql
@@ -8,11 +8,13 @@ BEGIN
     -- Existing rows and their classifications are never modified: unclassified
     -- fails closed downstream until someone classifies the code in step 2.
     --
-    -- Descriptions come from the ChartSegments reference data where available.
-    -- ERN codes (UCPath earnings codes) have no local description source;
-    -- the UCPath import fills those in from the PeopleSoft earnings table.
-    -- 'XXX' is the placeholder ERN code on fringe rows, which carry no FTE, so
-    -- classifying it is meaningless and it is not seeded.
+    -- Descriptions come from the ChartSegments reference data where available;
+    -- ERN descriptions come from the imported UcPathTransactions rows, which
+    -- carry UC_EARNCD_DESCR from the salary view. Existing Ern rows with a
+    -- NULL description are backfilled the same way (a description is metadata,
+    -- not a classification). 'XXX' is the placeholder ERN code on fringe rows,
+    -- which carry no FTE, so classifying it is meaningless and it is not
+    -- seeded.
 
     DECLARE @inserted TABLE ([SegmentType] NVARCHAR(20) NOT NULL);
 
@@ -45,10 +47,18 @@ BEGIN
     SELECT
         tv.SegmentType,
         tv.Code,
-        LEFT(cs.[Description], 300)
+        LEFT(COALESCE(cs.[Description], ern.[Description]), 300)
     FROM TransactionValues tv
     LEFT JOIN [data].[ChartSegments] cs
         ON cs.[SegmentName] = tv.SegmentType AND cs.[Code] = tv.Code
+    LEFT JOIN
+    (
+        SELECT [ErnCode], MAX([ErnDescription]) AS [Description]
+        FROM [data].[UcPathTransactions]
+        WHERE [ErnDescription] IS NOT NULL
+        GROUP BY [ErnCode]
+    ) ern
+        ON tv.SegmentType = 'Ern' AND ern.[ErnCode] = tv.Code
     WHERE NOT EXISTS
     (
         SELECT 1
@@ -56,6 +66,22 @@ BEGIN
         WHERE existing.[SegmentType] = tv.SegmentType
           AND existing.[Code] = tv.Code
     );
+
+    -- Backfill descriptions on Ern rows seeded before their description was
+    -- available (for example a code first seen on rows imported after the
+    -- code itself was seeded).
+    UPDATE sc
+    SET sc.[Description] = LEFT(ern.[Description], 300)
+    FROM [data].[SegmentClassifications] sc
+    JOIN
+    (
+        SELECT [ErnCode], MAX([ErnDescription]) AS [Description]
+        FROM [data].[UcPathTransactions]
+        WHERE [ErnDescription] IS NOT NULL
+        GROUP BY [ErnCode]
+    ) ern
+        ON ern.[ErnCode] = sc.[Code]
+    WHERE sc.[SegmentType] = 'Ern' AND sc.[Description] IS NULL;
 
     -- One row per segment type with the number of newly seeded codes
     -- (types with nothing new are omitted).

--- a/database/data/Tables/AETransactions.sql
+++ b/database/data/Tables/AETransactions.sql
@@ -43,6 +43,7 @@ CREATE TABLE [data].[AETransactions]
     -- Persisted exclusions for rules not owned by step 2 classification.
     -- NULL = not yet classified (fails closed downstream).
     [ExcludedByDate]                 BIT            NULL,
+    [AccountInUcPath]                BIT            NULL,  -- account also appears in UCPath data (dollars come from payroll detail instead)
 
     [LoadedAt]                       DATETIME2(3)   NULL CONSTRAINT [DF_AETransactions_LoadedAt] DEFAULT (SYSUTCDATETIME()),
     CONSTRAINT [PK_AETransactions] PRIMARY KEY CLUSTERED ([Id])

--- a/database/data/Tables/Projects.sql
+++ b/database/data/Tables/Projects.sql
@@ -14,9 +14,11 @@ CREATE TABLE [data].[Projects]
     [Is204]                       BIT           NOT NULL,
     [Sfn]                         NVARCHAR(7)   NOT NULL, -- from project number suffix: 201 | 202 | 204 | 205 | UNKNOWN
 
-    -- AE side (from PGMProjects via award number match). Null when a non-204
-    -- project has no PGM master data match; NIFA/PGM SFN agreement is checked
-    -- during Project Identification.
+    -- AE side (from PGMProjects via award number match). Null when the project
+    -- has no PGM master data match, which is the norm for non-204 projects
+    -- (Hatch and animal health are state funded with no AE project). The
+    -- Project Identification guard requires a match, and therefore a value,
+    -- for every 204 row; only the 204 rows feed the import carve-out lists.
     [AEProjectNumber]             NVARCHAR(50)  NULL,
     [SponsorAwardNumber]          NVARCHAR(100) NULL,
     [PrincipalInvestigatorNames]  NVARCHAR(MAX) NULL,

--- a/database/data/Tables/UcPathTransactions.sql
+++ b/database/data/Tables/UcPathTransactions.sql
@@ -23,6 +23,7 @@ CREATE TABLE [data].[UcPathTransactions]
     [FinanceDocTypeCd]       NVARCHAR(4)    NULL,
     -- Components of the natural key are required.
     [ErnCode]                NVARCHAR(3)    NOT NULL,   -- ERNCD for salary rows, 'XXX' for fringe rows (source ERNCD is blank on most fringe)
+    [ErnDescription]         NVARCHAR(120)  NULL,       -- UC_EARNCD_DESCR from the salary view; NULL on fringe rows. Feeds the Ern seed in SegmentClassifications
     [EmployeeId]             NVARCHAR(10)   NOT NULL,
     [EmployeeName]           NVARCHAR(100)  NULL,
     [PositionNumber]         NVARCHAR(8)    NOT NULL,   -- rare source rows without one are excluded at import

--- a/database/data/Views/v_BcbsDepartments.sql
+++ b/database/data/Views/v_BcbsDepartments.sql
@@ -1,0 +1,10 @@
+CREATE VIEW [data].[v_BcbsDepartments]
+AS
+-- Financial department codes under the BCBS00C parent department, a level C
+-- node (ParentLevel2Code) per the code suffix convention. BCBS expenses are
+-- only reportable on fund 13U02 (or via a 204 project), so the AE import
+-- limits its BCBS arm to these codes.
+SELECT [Code]
+FROM [data].[ChartSegments]
+WHERE [SegmentName] = 'FinancialDepartment'
+  AND [ParentLevel2Code] = 'BCBS00C';

--- a/database/data/Views/v_CaesAnrDepartments.sql
+++ b/database/data/Views/v_CaesAnrDepartments.sql
@@ -1,0 +1,11 @@
+CREATE VIEW [data].[v_CaesAnrDepartments]
+AS
+-- Financial department codes under the CAES (AAES00C) or ANR (9AAES0D)
+-- parent departments. The parents sit at fixed hierarchy levels, per the code
+-- suffix convention: AAES00C is a level C node (ParentLevel2Code) and 9AAES0D
+-- is level D (ParentLevel3Code). Drives the AE transaction import's wide net
+-- and is reusable by the expense display views.
+SELECT [Code]
+FROM [data].[ChartSegments]
+WHERE [SegmentName] = 'FinancialDepartment'
+  AND ([ParentLevel2Code] = 'AAES00C' OR [ParentLevel3Code] = '9AAES0D');

--- a/server.core/Data/AppDbContext.cs
+++ b/server.core/Data/AppDbContext.cs
@@ -12,6 +12,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<User> Users => Set<User>();
     public DbSet<WorkflowRun> WorkflowRuns => Set<WorkflowRun>();
     public DbSet<WorkflowChecklistItemState> WorkflowChecklistItemStates => Set<WorkflowChecklistItemState>();
+    public DbSet<ImportRun> ImportRuns => Set<ImportRun>();
+    public DbSet<ImportRunStage> ImportRunStages => Set<ImportRunStage>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -22,6 +24,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<User>().ToTable("Users", AppSchema);
         modelBuilder.Entity<WorkflowRun>().ToTable("WorkflowRun", AppSchema);
         modelBuilder.Entity<WorkflowChecklistItemState>().ToTable("WorkflowChecklistItemState", AppSchema);
+        modelBuilder.Entity<ImportRun>().ToTable("ImportRun", AppSchema);
+        modelBuilder.Entity<ImportRunStage>().ToTable("ImportRunStage", AppSchema);
 
         modelBuilder.Entity<WorkflowRun>()
             .HasIndex(run => run.IsCurrent)
@@ -39,5 +43,14 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .WithMany()
             .HasForeignKey(state => state.SourceImportLogId)
             .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ImportRun>()
+            .HasMany(run => run.Stages)
+            .WithOne(stage => stage.ImportRun)
+            .HasForeignKey(stage => stage.ImportRunId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<ImportRun>()
+            .HasIndex(run => run.Status);
     }
 }

--- a/server.core/Data/DataDbConnection.cs
+++ b/server.core/Data/DataDbConnection.cs
@@ -6,7 +6,9 @@ public static class DataDbConnection
 {
     public const string EnvironmentVariableName = "DATA_DB_CONNECTION";
     public const string ConnectionStringName = "DataConnection";
-    public const int ImportCommandTimeoutSeconds = 600;
+    // The AE pull streams ~465k rows through the linked server's row-by-row ODBC
+    // fetch, which takes over 10 minutes on its own; 600s timed out in practice.
+    public const int ImportCommandTimeoutSeconds = 3600;
 
     public static string Resolve(IConfiguration configuration, string? fallbackConnectionString)
     {

--- a/server.core/Data/DatamartConnection.cs
+++ b/server.core/Data/DatamartConnection.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Server.Core.Data;
+
+public static class DatamartConnection
+{
+    public const string EnvironmentVariableName = "DATAMART_CONNECTION";
+    public const string ConnectionStringName = "Datamart";
+
+    public static string Resolve(IConfiguration configuration)
+    {
+        var environmentValue = configuration[EnvironmentVariableName];
+        var connectionString = string.IsNullOrWhiteSpace(environmentValue)
+            ? configuration.GetConnectionString(ConnectionStringName)
+            : environmentValue;
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"No datamart connection string configured. Set the {EnvironmentVariableName} environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        return connectionString;
+    }
+}

--- a/server.core/Data/DbInitializer.cs
+++ b/server.core/Data/DbInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Server.Core.Data;
+using Server.Core.Import;
 
 public interface IDbInitializer
 {
@@ -25,6 +26,8 @@ public class DbInitializer : IDbInitializer
         _logger.LogInformation("Applying database migrations...");
         await _db.Database.MigrateAsync(cancellationToken);
         _logger.LogInformation("Migrations applied.");
+
+        await ImportRunOrchestrator.FailInterruptedRunsAsync(_db, cancellationToken);
 
         if (includeDevSeed)
         {

--- a/server.core/Domain/ImportRun.cs
+++ b/server.core/Domain/ImportRun.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Server.Core.Domain;
+
+public static class ImportRunStatus
+{
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string Failed = "Failed";
+}
+
+public class ImportRun
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public DateOnly CycleStart { get; set; }
+
+    public DateOnly CycleEnd { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string Status { get; set; } = string.Empty;
+
+    public Guid? TriggeredByEntraId { get; set; }
+
+    [MaxLength(200)]
+    public string? TriggeredByName { get; set; }
+
+    [MaxLength(320)]
+    public string? TriggeredByEmail { get; set; }
+
+    public DateTimeOffset StartedAt { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    public List<ImportRunStage> Stages { get; set; } = [];
+}

--- a/server.core/Domain/ImportRunStage.cs
+++ b/server.core/Domain/ImportRunStage.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Server.Core.Domain;
+
+public static class ImportStageStatus
+{
+    public const string Pending = "Pending";
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string Failed = "Failed";
+}
+
+public class ImportRunStage
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int ImportRunId { get; set; }
+
+    public ImportRun? ImportRun { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    public int Ordinal { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string Status { get; set; } = string.Empty;
+
+    public int? RowCount { get; set; }
+
+    // Optional human-readable summary shown instead of the raw row count,
+    // e.g. "479 AE projects, 364 NIFA projects" for the build projects stage.
+    [MaxLength(200)]
+    public string? Detail { get; set; }
+
+    public DateTimeOffset? StartedAt { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    public string? ErrorDetail { get; set; }
+}

--- a/server.core/Import/AeTransactionsImportService.cs
+++ b/server.core/Import/AeTransactionsImportService.cs
@@ -1,0 +1,206 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class AeTransactionsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string RemoteLinkedServer = "AE_Redshift_PROD";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[AETransactions]";
+
+    // source reader column -> destination table column. Id, ExcludedByDate, AccountInUcPath, LoadedAt are absent on
+    // purpose: the destination defaults apply to unmapped columns.
+    // Source names verified against the warehouse 2026-07-30; the table's two other
+    // columns (actual_flag, encumbrance_type_code) are filter-only and not pulled.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("entity", "Entity"),
+        ("fund", "Fund"),
+        ("financial_department", "FinancialDepartment"),
+        ("account", "Account"),
+        ("purpose", "Purpose"),
+        ("program", "Program"),
+        ("project", "Project"),
+        ("activity", "Activity"),
+        ("entity_description", "EntityDescription"),
+        ("fund_description", "FundDescription"),
+        ("financial_department_description", "FinancialDepartmentDescription"),
+        ("account_description", "AccountDescription"),
+        ("purpose_description", "PurposeDescription"),
+        ("program_description", "ProgramDescription"),
+        ("project_description", "ProjectDescription"),
+        ("activity_description", "ActivityDescription"),
+        ("document_type", "DocumentType"),
+        ("accounting_sequence_number", "AccountingSequenceNumber"),
+        ("tracking_no", "TrackingNo"),
+        ("reference", "Reference"),
+        ("journal_line_description", "JournalLineDescription"),
+        ("journal_acct_date", "JournalAcctDate"),
+        ("journal_name", "JournalName"),
+        ("journal_reference", "JournalReference"),
+        ("period_name", "PeriodName"),
+        ("journal_batch_name", "JournalBatchName"),
+        ("journal_source", "JournalSource"),
+        ("journal_category", "JournalCategory"),
+        ("batch_status", "BatchStatus"),
+        ("actual_amount", "Amount"),
+        ("commitment_amount", "CommitmentAmount"),
+        ("obligation_amount", "ObligationAmount"),
+        ("etl_load_dt", "EtlLoadDt"),
+    ];
+
+    // The department lists are DACPAC views so the display views built in the
+    // Expense Review work can share them.
+    private const string CaesAnrDepartmentsSql = "SELECT [Code] FROM [data].[v_CaesAnrDepartments]";
+    private const string BcbsDepartmentsSql = "SELECT [Code] FROM [data].[v_BcbsDepartments]";
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AeTransactionsImportService> _logger;
+
+    public AeTransactionsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<AeTransactionsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
+    {
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+
+        var caesAnrDepartments = await ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
+        var bcbsDepartments = await ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
+        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+
+        var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
+        var periods = ImportSql.PeriodNames(windowStart, windowEnd);
+
+        var remoteQuery = BuildRemoteQuery(periods, caesAnrDepartments, bcbsDepartments, projects204);
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var query = new SqlCommand($"EXEC (@remoteQuery) AT [{RemoteLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1)
+        {
+            Value = remoteQuery,
+        });
+
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable};", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        var rowsImported = (int)bulkCopy.RowsCopied64;
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation("Imported {RowCount} AE transactions", rowsImported);
+        return rowsImported;
+    }
+
+    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    public static string BuildRemoteQuery(
+        IReadOnlyList<string> periodNames,
+        IReadOnlyList<string> caesAnrDepartments,
+        IReadOnlyList<string> bcbsDepartments,
+        IReadOnlyList<string> projects204)
+    {
+        if (caesAnrDepartments.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "CAES/ANR department list is empty; run the ChartSegments reference import first.");
+        }
+
+        // The wide net: departments under CAES/ANR, plus any 204-mapped project, plus
+        // BCBS departments only on fund 13U02 (204 BCBS rows come in via the project arm).
+        // No purpose, account, fund, or activity filters here; those are visible
+        // exclusion reasons applied downstream.
+        var arms = new List<string>
+        {
+            $"financial_department IN ({ImportSql.QuoteList(caesAnrDepartments)})",
+        };
+
+        if (projects204.Count > 0)
+        {
+            arms.Add($"project IN ({ImportSql.QuoteList(projects204)})");
+        }
+
+        if (bcbsDepartments.Count > 0)
+        {
+            arms.Add($"(financial_department IN ({ImportSql.QuoteList(bcbsDepartments)}) AND fund = '13U02')");
+        }
+
+        return $"""
+            SELECT entity, fund, financial_department, account, purpose, program, project, activity,
+                entity_description, fund_description, financial_department_description, account_description,
+                purpose_description, program_description, project_description, activity_description,
+                document_type, accounting_sequence_number, tracking_no, reference, journal_line_description,
+                journal_acct_date, journal_name, journal_reference, period_name, journal_batch_name,
+                journal_source, journal_category, batch_status,
+                actual_amount, commitment_amount, obligation_amount, etl_load_dt
+            FROM ae_dwh.transactional_listing_report
+            WHERE actual_flag = 'A'
+              AND period_name IN ({ImportSql.QuoteList(periodNames)})
+              AND ({string.Join("\n               OR ", arms)})
+            """;
+    }
+}

--- a/server.core/Import/AeTransactionsImportService.cs
+++ b/server.core/Import/AeTransactionsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class AeTransactionsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -77,15 +76,7 @@ public sealed class AeTransactionsImportService
 
     public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());
@@ -93,9 +84,9 @@ public sealed class AeTransactionsImportService
         await using var destination = new SqlConnection(destinationConnectionString);
         await destination.OpenAsync(cancellationToken);
 
-        var caesAnrDepartments = await ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
-        var bcbsDepartments = await ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
-        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var caesAnrDepartments = await ImportSql.ReadListAsync(destination, CaesAnrDepartmentsSql, cancellationToken);
+        var bcbsDepartments = await ImportSql.ReadListAsync(destination, BcbsDepartmentsSql, cancellationToken);
+        var projects204 = await ImportSql.ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
 
         var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
         var periods = ImportSql.PeriodNames(windowStart, windowEnd);
@@ -143,19 +134,6 @@ public sealed class AeTransactionsImportService
 
         _logger.LogInformation("Imported {RowCount} AE transactions", rowsImported);
         return rowsImported;
-    }
-
-    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
-    {
-        var values = new List<string>();
-        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
-        await using var reader = await command.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            values.Add(reader.GetString(0));
-        }
-
-        return values;
     }
 
     public static string BuildRemoteQuery(

--- a/server.core/Import/ChartSegmentsImportService.cs
+++ b/server.core/Import/ChartSegmentsImportService.cs
@@ -1,0 +1,156 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class ChartSegmentsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string RemoteLinkedServer = "AE_Redshift_PROD";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[ChartSegments]";
+
+    public static readonly (string SegmentName, string SourceTable)[] Segments =
+    [
+        ("Entity", "ae_dwh.erp_entity"),
+        ("Fund", "ae_dwh.erp_fund"),
+        ("FinancialDepartment", "ae_dwh.erp_fin_dept"),
+        ("Account", "ae_dwh.erp_account"),
+        ("Purpose", "ae_dwh.erp_purpose"),
+        ("Program", "ae_dwh.erp_program"),
+        ("Project", "ae_dwh.erp_project"),
+        ("Activity", "ae_dwh.erp_activity"),
+    ];
+
+    // source reader column -> destination table column. LoadedAt is absent on
+    // purpose: the destination default applies to unmapped columns.
+    // Source names verified against the warehouse 2026-07-30; all eight erp_*
+    // tables share this schema.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("segment_name", "SegmentName"),
+        ("code", "Code"),
+        ("value_id", "ValueId"),
+        ("description", "Description"),
+        ("value_desc", "ValueDesc"),
+        ("hierarchy_depth", "HierarchyDepth"),
+        ("summary_flag", "SummaryFlag"),
+        ("enabled_flag", "EnabledFlag"),
+        ("start_date_active", "StartDateActive"),
+        ("end_date_active", "EndDateActive"),
+        ("parent_level_0_code", "ParentLevel0Code"),
+        ("parent_level_1_code", "ParentLevel1Code"),
+        ("parent_level_2_code", "ParentLevel2Code"),
+        ("parent_level_3_code", "ParentLevel3Code"),
+        ("parent_level_4_code", "ParentLevel4Code"),
+        ("parent_level_5_code", "ParentLevel5Code"),
+    ];
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ChartSegmentsImportService> _logger;
+
+    public ChartSegmentsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<ChartSegmentsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportSegmentAsync(string segmentName, CancellationToken cancellationToken = default)
+    {
+        var (_, sourceTable) = Segments.Single(s => s.SegmentName == segmentName);
+
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var query = new SqlCommand($"EXEC (@remoteQuery) AT [{RemoteLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1)
+        {
+            Value = BuildRemoteQuery(segmentName, sourceTable),
+        });
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable} WHERE [SegmentName] = @segmentName;", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            delete.Parameters.Add(new SqlParameter("@segmentName", SqlDbType.NVarChar, 30) { Value = segmentName });
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        var rowsImported = (int)bulkCopy.RowsCopied64;
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation("Imported {RowCount} {Segment} chart segments", rowsImported, segmentName);
+        return rowsImported;
+    }
+
+    /// <summary>
+    /// Builds the Redshift query run on the warehouse via the pass-through. The segment_name
+    /// is cast to a narrow VARCHAR(30) so MSDASQL binds it inline rather than as a streamed LOB.
+    /// The Redshift ODBC driver reports wide/untyped VARCHAR as SQL_LONGVARCHAR (streamed), which
+    /// EXEC ... AT cannot stream, failing with error 7341. Explicit narrow types force inline binding.
+    ///
+    /// Column names verified against the warehouse 2026-07-30.
+    /// </summary>
+    public static string BuildRemoteQuery(string segmentName, string sourceTable)
+    {
+        if (!Segments.Any(s => s.SegmentName == segmentName))
+        {
+            throw new ArgumentException($"Unknown segment name '{segmentName}'.", nameof(segmentName));
+        }
+
+        return $"""
+            SELECT CAST('{segmentName}' AS VARCHAR(30)) AS segment_name,
+                code, value_id, description, value_desc, hierarchy_depth,
+                summary_flag, enabled_flag, start_date_active, end_date_active,
+                parent_level_0_code, parent_level_1_code, parent_level_2_code,
+                parent_level_3_code, parent_level_4_code, parent_level_5_code
+            FROM {sourceTable}
+            WHERE code IS NOT NULL
+            """;
+    }
+}

--- a/server.core/Import/ChartSegmentsImportService.cs
+++ b/server.core/Import/ChartSegmentsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class ChartSegmentsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -69,15 +68,7 @@ public sealed class ChartSegmentsImportService
     {
         var (_, sourceTable) = Segments.Single(s => s.SegmentName == segmentName);
 
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());

--- a/server.core/Import/ImportReadinessCheck.cs
+++ b/server.core/Import/ImportReadinessCheck.cs
@@ -1,0 +1,51 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public interface IImportReadinessCheck
+{
+    /// <summary>
+    /// Returns the reason an import run cannot start for the given cycle, or
+    /// null when it can. Reads [data].[ImportBlockingIssueForCycle], the same
+    /// definition the BuildProjects guard uses, so a not-ready run is rejected
+    /// at the trigger instead of failing at the build projects stage mid-run.
+    /// </summary>
+    Task<string?> GetBlockingIssueAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken);
+}
+
+public sealed class ImportReadinessCheck : IImportReadinessCheck
+{
+    private const string CheckSql =
+        "SELECT [data].[ImportBlockingIssueForCycle](@cycleStart, @cycleEnd)";
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+
+    public ImportReadinessCheck(DataDbContext dataDbContext, IConfiguration configuration)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+    }
+
+    public async Task<string?> GetBlockingIssueAsync(
+        DateOnly cycleStart,
+        DateOnly cycleEnd,
+        CancellationToken cancellationToken)
+    {
+        var connectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = new SqlCommand(CheckSql, connection);
+        command.Parameters.Add(new SqlParameter("@cycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@cycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is DBNull or null ? null : (string)result;
+    }
+}

--- a/server.core/Import/ImportRunOrchestrator.cs
+++ b/server.core/Import/ImportRunOrchestrator.cs
@@ -1,0 +1,89 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+using Server.Core.Domain;
+
+namespace Server.Core.Import;
+
+public sealed class ImportRunOrchestrator
+{
+    private readonly AppDbContext _appDb;
+    private readonly IImportStageProvider _stageProvider;
+    private readonly ILogger<ImportRunOrchestrator> _logger;
+
+    public ImportRunOrchestrator(
+        AppDbContext appDb,
+        IImportStageProvider stageProvider,
+        ILogger<ImportRunOrchestrator> logger)
+    {
+        _appDb = appDb;
+        _stageProvider = stageProvider;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(int runId, CancellationToken cancellationToken = default)
+    {
+        var run = await _appDb.ImportRuns
+            .Include(r => r.Stages)
+            .SingleAsync(r => r.Id == runId, cancellationToken);
+
+        var context = new ImportRunContext(run.Id, run.CycleStart, run.CycleEnd);
+        var stagesByName = run.Stages.ToDictionary(s => s.Name);
+
+        foreach (var stage in _stageProvider.BuildStages(context))
+        {
+            var record = stagesByName[stage.Name];
+            record.Status = ImportStageStatus.Running;
+            record.StartedAt = DateTimeOffset.UtcNow;
+            await _appDb.SaveChangesAsync(cancellationToken);
+
+            try
+            {
+                var result = await stage.ExecuteAsync(cancellationToken);
+                record.RowCount = result.RowCount;
+                record.Detail = result.Detail;
+                record.Status = ImportStageStatus.Succeeded;
+                record.CompletedAt = DateTimeOffset.UtcNow;
+                await _appDb.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Import stage {Stage} failed for run {RunId}", stage.Name, runId);
+                record.Status = ImportStageStatus.Failed;
+                record.ErrorDetail = ex.ToString();
+                record.CompletedAt = DateTimeOffset.UtcNow;
+                run.Status = ImportRunStatus.Failed;
+                run.CompletedAt = DateTimeOffset.UtcNow;
+                await _appDb.SaveChangesAsync(CancellationToken.None);
+                return;
+            }
+        }
+
+        run.Status = ImportRunStatus.Succeeded;
+        run.CompletedAt = DateTimeOffset.UtcNow;
+        await _appDb.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task FailInterruptedRunsAsync(AppDbContext appDb, CancellationToken cancellationToken = default)
+    {
+        var interrupted = await appDb.ImportRuns
+            .Include(r => r.Stages)
+            .Where(r => r.Status == ImportRunStatus.Running)
+            .ToListAsync(cancellationToken);
+
+        foreach (var run in interrupted)
+        {
+            run.Status = ImportRunStatus.Failed;
+            run.CompletedAt = DateTimeOffset.UtcNow;
+
+            foreach (var stage in run.Stages.Where(s => s.Status == ImportStageStatus.Running))
+            {
+                stage.Status = ImportStageStatus.Failed;
+                stage.ErrorDetail = "Interrupted by application restart.";
+                stage.CompletedAt = DateTimeOffset.UtcNow;
+            }
+        }
+
+        await appDb.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/server.core/Import/ImportSql.cs
+++ b/server.core/Import/ImportSql.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using Microsoft.Data.SqlClient;
+using Server.Core.Data;
 
 namespace Server.Core.Import;
 
@@ -35,4 +37,20 @@ public static class ImportSql
 
     public static (DateOnly Start, DateOnly End) BufferedWindow(DateOnly cycleStart, DateOnly cycleEnd) =>
         (cycleStart.AddMonths(-3), cycleEnd.AddMonths(3));
+
+    public static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection)
+        {
+            CommandTimeout = DataDbConnection.ImportCommandTimeoutSeconds,
+        };
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
 }

--- a/server.core/Import/ImportSql.cs
+++ b/server.core/Import/ImportSql.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace Server.Core.Import;
+
+public static class ImportSql
+{
+    // The 204 carve-out list shared by the AE and UCPath imports. Every 204 row
+    // has an AEProjectNumber by the readiness guard; the null filter is defense
+    // in depth.
+    public const string Projects204Sql = """
+        SELECT DISTINCT [AEProjectNumber] FROM [data].[Projects]
+        WHERE [Sfn] = '204' AND [AEProjectNumber] IS NOT NULL
+        """;
+
+    // Period names must match how ClassifyTransactions generates its cycle set
+    // (FORMAT(@month, 'MMM-yy', 'en-US')) so pull and stamp agree.
+    public static List<string> PeriodNames(DateOnly start, DateOnly end)
+    {
+        var names = new List<string>();
+        var month = new DateOnly(start.Year, start.Month, 1);
+        while (month <= end)
+        {
+            names.Add(month.ToString("MMM-yy", CultureInfo.GetCultureInfo("en-US")));
+            month = month.AddMonths(1);
+        }
+
+        return names;
+    }
+
+    public static string QuoteList(IEnumerable<string> values) =>
+        string.Join(",", values.Select(v => $"'{v.Replace("'", "''")}'"));
+
+    public static int HoursInFederalFiscalYear(int federalFiscalYear) =>
+        federalFiscalYear % 4 == 0 ? 2096 : 2088;
+
+    public static (DateOnly Start, DateOnly End) BufferedWindow(DateOnly cycleStart, DateOnly cycleEnd) =>
+        (cycleStart.AddMonths(-3), cycleEnd.AddMonths(3));
+}

--- a/server.core/Import/ImportStage.cs
+++ b/server.core/Import/ImportStage.cs
@@ -1,0 +1,46 @@
+namespace Server.Core.Import;
+
+public sealed record ImportRunContext(int RunId, DateOnly CycleStart, DateOnly CycleEnd);
+
+public sealed record ImportStageResult(int RowCount, string? Detail = null);
+
+public sealed record ImportStage(string Name, Func<CancellationToken, Task<ImportStageResult>> ExecuteAsync)
+{
+    /// <summary>Adapts a stage that reports only a row count.</summary>
+    public static ImportStage FromRowCount(string name, Func<CancellationToken, Task<int>> executeAsync) =>
+        new(name, async ct => new ImportStageResult(await executeAsync(ct)));
+}
+
+public interface IImportStageProvider
+{
+    IReadOnlyList<string> StageNames { get; }
+
+    IReadOnlyList<ImportStage> BuildStages(ImportRunContext context);
+}
+
+public static class ImportStageNames
+{
+    public const string ChartSegmentsPrefix = "ChartSegments: ";
+    public const string BuildProjects = "Build projects";
+    public const string AeTransactions = "AE transactions";
+    public const string UcPathTransactions = "UCPath transactions";
+    public const string SeedSegmentClassifications = "Seed segment classifications";
+    public const string ClassifyTransactions = "Classify transactions";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        ChartSegmentsPrefix + "Entity",
+        ChartSegmentsPrefix + "Fund",
+        ChartSegmentsPrefix + "Financial Department",
+        ChartSegmentsPrefix + "Account",
+        ChartSegmentsPrefix + "Purpose",
+        ChartSegmentsPrefix + "Program",
+        ChartSegmentsPrefix + "Project",
+        ChartSegmentsPrefix + "Activity",
+        BuildProjects,
+        AeTransactions,
+        UcPathTransactions,
+        SeedSegmentClassifications,
+        ClassifyTransactions,
+    ];
+}

--- a/server.core/Import/ImportStageProvider.cs
+++ b/server.core/Import/ImportStageProvider.cs
@@ -1,0 +1,52 @@
+namespace Server.Core.Import;
+
+public sealed class ImportStageProvider : IImportStageProvider
+{
+    private readonly ChartSegmentsImportService _chartSegments;
+    private readonly AeTransactionsImportService _aeTransactions;
+    private readonly UcPathTransactionsImportService _ucPathTransactions;
+    private readonly SprocStageService _sprocs;
+
+    public ImportStageProvider(
+        ChartSegmentsImportService chartSegments,
+        AeTransactionsImportService aeTransactions,
+        UcPathTransactionsImportService ucPathTransactions,
+        SprocStageService sprocs)
+    {
+        _chartSegments = chartSegments;
+        _aeTransactions = aeTransactions;
+        _ucPathTransactions = ucPathTransactions;
+        _sprocs = sprocs;
+    }
+
+    public IReadOnlyList<string> StageNames => ImportStageNames.All;
+
+    public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context)
+    {
+        var stages = new List<ImportStage>();
+
+        // Stage display names split FinancialDepartment into words; the service
+        // keys stay the stored SegmentName form.
+        var displayNames = new Dictionary<string, string> { ["FinancialDepartment"] = "Financial Department" };
+        foreach (var (segmentName, _) in ChartSegmentsImportService.Segments)
+        {
+            var display = displayNames.GetValueOrDefault(segmentName, segmentName);
+            stages.Add(ImportStage.FromRowCount(
+                ImportStageNames.ChartSegmentsPrefix + display,
+                ct => _chartSegments.ImportSegmentAsync(segmentName, ct)));
+        }
+
+        stages.Add(new ImportStage(ImportStageNames.BuildProjects,
+            ct => _sprocs.BuildProjectsAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.AeTransactions,
+            ct => _aeTransactions.ImportAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.UcPathTransactions,
+            ct => _ucPathTransactions.ImportAsync(context.CycleStart, context.CycleEnd, ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.SeedSegmentClassifications,
+            ct => _sprocs.SeedSegmentClassificationsAsync(ct)));
+        stages.Add(ImportStage.FromRowCount(ImportStageNames.ClassifyTransactions,
+            ct => _sprocs.ClassifyTransactionsAsync(context.CycleStart, context.CycleEnd, ct)));
+
+        return stages;
+    }
+}

--- a/server.core/Import/PgmProjectsImportService.cs
+++ b/server.core/Import/PgmProjectsImportService.cs
@@ -9,8 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class PgmProjectsImportService : IPgmProjectsImportService
 {
-    public const string ConnectionStringName = "Datamart";
-
     public const string RemoteLinkedServer = "AE_Redshift_PROD";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -93,16 +91,7 @@ public sealed class PgmProjectsImportService : IPgmProjectsImportService
 
     public async Task<PgmProjectsImportResult> ImportAsync(DateOnly reportDate, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());

--- a/server.core/Import/SprocStageService.cs
+++ b/server.core/Import/SprocStageService.cs
@@ -1,0 +1,98 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class SprocStageService
+{
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+
+    public SprocStageService(DataDbContext dataDbContext, IConfiguration configuration)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+    }
+
+    public async Task<ImportStageResult> BuildProjectsAsync(
+        DateOnly cycleStart,
+        DateOnly cycleEnd,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[BuildProjects]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        command.Parameters.Add(new SqlParameter("@CycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@CycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return new ImportStageResult(0);
+        }
+
+        var aeProjects = reader.GetInt32(reader.GetOrdinal("AeProjects"));
+        var nifaProjects = reader.GetInt32(reader.GetOrdinal("NifaProjects"));
+        return new ImportStageResult(
+            aeProjects,
+            $"{aeProjects:N0} AE projects, {nifaProjects:N0} NIFA projects");
+    }
+
+    public async Task<int> SeedSegmentClassificationsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[SeedSegmentClassifications]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+
+        var total = 0;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        var insertedCountOrdinal = reader.GetOrdinal("InsertedCount");
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            total += reader.GetInt32(insertedCountOrdinal);
+        }
+
+        return total;
+    }
+
+    public async Task<int> ClassifyTransactionsAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand("[data].[ClassifyTransactions]", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        command.Parameters.Add(new SqlParameter("@cycleStart", SqlDbType.Date) { Value = cycleStart.ToDateTime(TimeOnly.MinValue) });
+        command.Parameters.Add(new SqlParameter("@cycleEnd", SqlDbType.Date) { Value = cycleEnd.ToDateTime(TimeOnly.MinValue) });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return 0;
+        }
+
+        var aeRowsClassified = reader.GetInt32(reader.GetOrdinal("AeRowsClassified"));
+        var ucPathRowsClassified = reader.GetInt32(reader.GetOrdinal("UcPathRowsClassified"));
+        return aeRowsClassified + ucPathRowsClassified;
+    }
+
+    private async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connectionString = DataDbConnection.Resolve(_configuration, _dataDbContext.Database.GetConnectionString());
+        var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+}

--- a/server.core/Import/UcPathTransactionsImportService.cs
+++ b/server.core/Import/UcPathTransactionsImportService.cs
@@ -1,0 +1,375 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Server.Core.Data;
+
+namespace Server.Core.Import;
+
+public sealed class UcPathTransactionsImportService
+{
+    public const string ConnectionStringName = "Datamart";
+    public const string HcmLinkedServer = "AIT_BISTG_PRD-CAES_HCMODS_APPUSER";
+
+    private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
+    private const string DestinationTable = "[data].[UcPathTransactions]";
+
+    // source reader column -> destination table column. EmployeeName, ExcludedByDate, AccountNotInAE, LoadedAt are absent on
+    // purpose: the destination defaults apply to unmapped columns. FinanceDocTypeCd and
+    // RateTypeCd are also unmapped: neither column exists on the labor views
+    // (verified against the warehouse 2026-07-30), so they stay NULL.
+    private static readonly (string Source, string Destination)[] ColumnMappings =
+    [
+        ("labor_transaction_id", "LaborTransactionId"),
+        ("entity", "Entity"),
+        ("fund", "Fund"),
+        ("financial_department", "FinancialDepartment"),
+        ("parent_department", "ParentDepartment"),
+        ("account", "Account"),
+        ("purpose", "Purpose"),
+        ("program", "Program"),
+        ("project", "Project"),
+        ("activity", "Activity"),
+        ("erncd", "ErnCode"),
+        ("ern_description", "ErnDescription"),
+        ("employee_id", "EmployeeId"),
+        ("position_number", "PositionNumber"),
+        ("eff_dt", "EffDt"),
+        ("job_code", "JobCode"),
+        ("hours", "Hours"),
+        ("amount", "Amount"),
+        ("pay_rate", "PayRate"),
+        ("calculated_fte", "CalculatedFte"),
+        ("pay_period_end_date", "PayPeriodEndDate"),
+        ("fringe_benefit_salary_cd", "FringeBenefitSalaryCd"),
+        ("paid_percent", "PaidPercent"),
+        ("ern_derived_percent", "ErnDerivedPercent"),
+        ("fiscal_year", "FiscalYear"),
+        ("period", "Period"),
+        ("emp_rcd", "EmpRcd"),
+        ("eff_seq", "EffSeq"),
+    ];
+
+    private readonly DataDbContext _dataDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<UcPathTransactionsImportService> _logger;
+
+    public UcPathTransactionsImportService(
+        DataDbContext dataDbContext,
+        IConfiguration configuration,
+        ILogger<UcPathTransactionsImportService> logger)
+    {
+        _dataDbContext = dataDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
+    {
+        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
+            ?? _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+        {
+            throw new InvalidOperationException(
+                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
+                $"or configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var destinationConnectionString = DataDbConnection.Resolve(
+            _configuration,
+            _dataDbContext.Database.GetConnectionString());
+
+        await using var destination = new SqlConnection(destinationConnectionString);
+        await destination.OpenAsync(cancellationToken);
+
+        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
+        var fteDenominatorHours = ImportSql.HoursInFederalFiscalYear(cycleEnd.Year);
+
+        var salarySql = BuildSalaryQuery(projects204, fteDenominatorHours);
+        var fringSql = BuildFringeQuery(projects204);
+
+        await using var source = new SqlConnection(sourceConnectionString);
+        await source.OpenAsync(cancellationToken);
+
+        await using var salaryQuery = new SqlCommand(
+            $"EXEC (@remoteQuery, @windowStart, @windowEnd) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        salaryQuery.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = salarySql });
+        salaryQuery.Parameters.Add(new SqlParameter("@windowStart", SqlDbType.Date) { Value = windowStart });
+        salaryQuery.Parameters.Add(new SqlParameter("@windowEnd", SqlDbType.Date) { Value = windowEnd });
+
+        await using var fringeQuery = new SqlCommand(
+            $"EXEC (@remoteQuery, @windowStart, @windowEnd) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        };
+        fringeQuery.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = fringSql });
+        fringeQuery.Parameters.Add(new SqlParameter("@windowStart", SqlDbType.Date) { Value = windowStart });
+        fringeQuery.Parameters.Add(new SqlParameter("@windowEnd", SqlDbType.Date) { Value = windowEnd });
+
+        await using var transaction = (SqlTransaction)await destination.BeginTransactionAsync(cancellationToken);
+
+        await using (var delete = new SqlCommand(
+            $"DELETE FROM {DestinationTable};", destination, transaction))
+        {
+            delete.CommandTimeout = CommandTimeoutSeconds;
+            await delete.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        var totalRowsCopied =
+            await BulkCopyAsync(salaryQuery, destination, transaction, cancellationToken)
+            + await BulkCopyAsync(fringeQuery, destination, transaction, cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+
+        var rowsImported = (int)totalRowsCopied;
+        _logger.LogInformation("Imported {RowCount} UCPath transactions", rowsImported);
+
+        await EnrichEmployeeNamesAsync(source, destination, cancellationToken);
+        await EnrichJobCodesAsync(source, destination, windowEnd, cancellationToken);
+
+        return rowsImported;
+    }
+
+    private static async Task<long> BulkCopyAsync(
+        SqlCommand query,
+        SqlConnection destination,
+        SqlTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var bulkCopy = new SqlBulkCopy(destination, SqlBulkCopyOptions.Default, transaction)
+        {
+            DestinationTableName = DestinationTable,
+            BulkCopyTimeout = CommandTimeoutSeconds,
+        };
+        foreach (var (sourceColumn, destinationColumn) in ColumnMappings)
+        {
+            bulkCopy.ColumnMappings.Add(sourceColumn, destinationColumn);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync(cancellationToken))
+        {
+            await bulkCopy.WriteToServerAsync(reader, cancellationToken);
+        }
+
+        return bulkCopy.RowsCopied64;
+    }
+
+    private async Task EnrichEmployeeNamesAsync(SqlConnection source, SqlConnection destination, CancellationToken ct)
+    {
+        await using (var create = new SqlCommand(
+            "CREATE TABLE #EmployeeNames ([EmployeeId] NVARCHAR(10) NOT NULL, [EmployeeName] NVARCHAR(100) NULL);",
+            destination))
+        {
+            await create.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var query = new SqlCommand($"EXEC (@remoteQuery) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildNamesQuery() });
+            using var bulkCopy = new SqlBulkCopy(destination) { DestinationTableName = "#EmployeeNames", BulkCopyTimeout = CommandTimeoutSeconds };
+            bulkCopy.ColumnMappings.Add("employee_id", "EmployeeId");
+            bulkCopy.ColumnMappings.Add("employee_name", "EmployeeName");
+            await using var reader = await query.ExecuteReaderAsync(ct);
+            await bulkCopy.WriteToServerAsync(reader, ct);
+        }
+
+        await using (var update = new SqlCommand(
+            """
+            -- UCD_PS_NAMES_V verified one row per EMPLID (2026-07-30: 27,275 rows, 27,275
+            -- distinct EMPLIDs); MAX() keeps the update deterministic if that ever changes
+            UPDATE t SET [EmployeeName] = LEFT(n.[EmployeeName], 100)
+            FROM [data].[UcPathTransactions] t
+            JOIN (SELECT [EmployeeId], MAX([EmployeeName]) AS [EmployeeName] FROM #EmployeeNames GROUP BY [EmployeeId]) n
+                ON n.[EmployeeId] = t.[EmployeeId];
+            DROP TABLE #EmployeeNames;
+            """, destination)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            await update.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private async Task EnrichJobCodesAsync(SqlConnection source, SqlConnection destination, DateOnly effDtCeiling, CancellationToken ct)
+    {
+        await using (var create = new SqlCommand(
+            "CREATE TABLE #PeopleSoftJobs ([EmployeeId] NVARCHAR(10), [EmpRcd] SMALLINT, [EffDt] DATETIME2(7), [EffSeq] SMALLINT, [PositionNumber] NVARCHAR(8), [TitleCode] NVARCHAR(4));",
+            destination))
+        {
+            await create.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var query = new SqlCommand($"EXEC (@remoteQuery, @effDtCeiling) AT [{HcmLinkedServer}];", source)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            query.Parameters.Add(new SqlParameter("@remoteQuery", SqlDbType.NVarChar, -1) { Value = BuildJobCodeQuery() });
+            query.Parameters.Add(new SqlParameter("@effDtCeiling", SqlDbType.Date) { Value = effDtCeiling });
+            using var bulkCopy = new SqlBulkCopy(destination) { DestinationTableName = "#PeopleSoftJobs", BulkCopyTimeout = CommandTimeoutSeconds };
+            bulkCopy.ColumnMappings.Add("employee_id", "EmployeeId");
+            bulkCopy.ColumnMappings.Add("emp_rcd", "EmpRcd");
+            bulkCopy.ColumnMappings.Add("eff_dt", "EffDt");
+            bulkCopy.ColumnMappings.Add("eff_seq", "EffSeq");
+            bulkCopy.ColumnMappings.Add("position_number", "PositionNumber");
+            bulkCopy.ColumnMappings.Add("title_code", "TitleCode");
+            await using var reader = await query.ExecuteReaderAsync(ct);
+            await bulkCopy.WriteToServerAsync(reader, ct);
+        }
+
+        await using (var update = new SqlCommand(
+            """
+            WITH Ranked AS (
+                SELECT *,
+                    ROW_NUMBER() OVER (PARTITION BY [EmployeeId], [EmpRcd], [EffDt] ORDER BY [EffSeq] DESC) AS DateRank,
+                    ROW_NUMBER() OVER (PARTITION BY [EmployeeId], [EmpRcd], [PositionNumber] ORDER BY [EffDt] DESC, [EffSeq] DESC) AS PositionRank
+                FROM #PeopleSoftJobs
+            )
+            UPDATE t
+            SET [JobCode] = COALESCE(exactMatch.[TitleCode], positionMatch.[TitleCode])
+            FROM [data].[UcPathTransactions] t
+            LEFT JOIN (SELECT * FROM Ranked WHERE DateRank = 1) exactMatch
+                ON exactMatch.[EmployeeId] = t.[EmployeeId] AND exactMatch.[EmpRcd] = t.[EmpRcd]
+               AND exactMatch.[EffDt] = t.[EffDt] AND exactMatch.[EffSeq] = t.[EffSeq]
+            LEFT JOIN (SELECT * FROM Ranked WHERE PositionRank = 1) positionMatch
+                ON positionMatch.[EmployeeId] = t.[EmployeeId] AND positionMatch.[EmpRcd] = t.[EmpRcd]
+               AND positionMatch.[PositionNumber] = t.[PositionNumber]
+            WHERE t.[JobCode] IS NULL OR t.[JobCode] = '';
+            DROP TABLE #PeopleSoftJobs;
+            """, destination)
+        {
+            CommandTimeout = CommandTimeoutSeconds,
+        })
+        {
+            await update.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    public static string BuildNamesQuery() =>
+        """
+        SELECT EMPLID AS employee_id, NAME AS employee_name
+        FROM CAES_HCMODS.UCD_PS_NAMES_V
+        """;
+
+    // PS_JOB_V columns verified against the warehouse 2026-07-30.
+    public static string BuildJobCodeQuery() =>
+        """
+        SELECT EMPLID AS employee_id, EMPL_RCD AS emp_rcd, EFFDT AS eff_dt, EFFSEQ AS eff_seq,
+            POSITION_NBR AS position_number, SUBSTR(JOBCODE, -4) AS title_code
+        FROM CAES_HCMODS.PS_JOB_V
+        WHERE JOBCODE <> 'CONV'
+          AND JOBCODE NOT LIKE ' %'
+          AND EFFDT <= ?
+        """;
+
+    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
+    {
+        var values = new List<string>();
+        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    // Column names verified against the warehouse 2026-07-30 (ALL_TAB_COLUMNS for
+    // both labor views). PAY_END_DT is the pay period end date used for the window
+    // filter; UC_EARN_END_DT also exists but the 2025 notes say not to use it.
+    public static string BuildSalaryQuery(IReadOnlyList<string> projects204, int fteDenominatorHours) =>
+        $"""
+        SELECT
+            JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ || '_' || EMPLID || '_' || EMPL_RCD || '_' || ERNCD || '_' || RUN_ID AS labor_transaction_id,
+            NULLIF(TRIM(OPERATING_UNIT), '') AS entity,
+            NULLIF(TRIM(FUND_CODE), '') AS fund,
+            NULLIF(TRIM(DEPTID_CF), '') AS financial_department,
+            NULLIF(TRIM(UC_DEPTID_ROLLUP), '') AS parent_department,
+            NULLIF(TRIM(ACCOUNT), '') AS account,
+            NULLIF(TRIM(CLASS_FLD), '') AS purpose,
+            NULLIF(TRIM(PROGRAM_CODE), '') AS program,
+            NULLIF(TRIM(PROJECT_ID), '') AS project,
+            NULLIF(TRIM(CHARTFIELD1), '') AS activity,
+            NULLIF(TRIM(ERNCD), '') AS erncd,
+            NULLIF(TRIM(UC_EARNCD_DESCR), '') AS ern_description,
+            NULLIF(TRIM(EMPLID), '') AS employee_id,
+            NULLIF(TRIM(POSITION_NBR), '') AS position_number,
+            EFFDT AS eff_dt,
+            NULLIF(TRIM(SUBSTR(JOBCODE, -4)), '') AS job_code,
+            HOURS1 AS hours,
+            MONETARY_AMOUNT AS amount,
+            CASE WHEN HOURS1 <> 0 THEN MONETARY_AMOUNT / HOURS1 END AS pay_rate,
+            HOURS1 / {fteDenominatorHours} AS calculated_fte,
+            PAY_END_DT AS pay_period_end_date,
+            'S' AS fringe_benefit_salary_cd,
+            UC_PCT_TOT_PAY AS paid_percent,
+            UC_DRV_EFT_PCT AS ern_derived_percent,
+            FISCAL_YEAR AS fiscal_year,
+            TO_CHAR(ACCOUNTING_PERIOD) AS period,
+            EMPL_RCD AS emp_rcd,
+            EFFSEQ AS eff_seq
+        FROM CAES_HCMODS.PS_UC_LL_SAL_DTL_V
+        WHERE BUSINESS_UNIT IN ('DVCMP','UCANR')
+          AND OPERATING_UNIT IN ('3310','3110')
+          AND DML_IND <> 'D'
+          AND PAY_END_DT BETWEEN ? AND ?
+          AND NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL
+          AND (FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78'){Source204Arm(projects204)})
+        """;
+
+    // Column names verified against the warehouse 2026-07-30. The fringe view has
+    // no JOBCODE, hours, or percent columns; job_code is backfilled by the title
+    // code enrichment step.
+    public static string BuildFringeQuery(IReadOnlyList<string> projects204) =>
+        $"""
+        SELECT
+            JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ || '_' || EMPLID || '_' || EMPL_RCD || '_' || 'XXX' || '_' || RUN_ID AS labor_transaction_id,
+            NULLIF(TRIM(OPERATING_UNIT), '') AS entity,
+            NULLIF(TRIM(FUND_CODE), '') AS fund,
+            NULLIF(TRIM(DEPTID_CF), '') AS financial_department,
+            NULLIF(TRIM(UC_DEPTID_ROLLUP), '') AS parent_department,
+            NULLIF(TRIM(ACCOUNT), '') AS account,
+            NULLIF(TRIM(CLASS_FLD), '') AS purpose,
+            NULLIF(TRIM(PROGRAM_CODE), '') AS program,
+            NULLIF(TRIM(PROJECT_ID), '') AS project,
+            NULLIF(TRIM(CHARTFIELD1), '') AS activity,
+            'XXX' AS erncd,
+            CAST(NULL AS VARCHAR2(120)) AS ern_description,
+            NULLIF(TRIM(EMPLID), '') AS employee_id,
+            NULLIF(TRIM(POSITION_NBR), '') AS position_number,
+            EFFDT AS eff_dt,
+            CAST(NULL AS VARCHAR2(24)) AS job_code,
+            0 AS hours,
+            MONETARY_AMOUNT AS amount,
+            CAST(NULL AS DECIMAL(17,4)) AS pay_rate,
+            0 AS calculated_fte,
+            PAY_END_DT AS pay_period_end_date,
+            'F' AS fringe_benefit_salary_cd,
+            CAST(NULL AS DECIMAL(7,4)) AS paid_percent,
+            CAST(NULL AS DECIMAL(7,4)) AS ern_derived_percent,
+            FISCAL_YEAR AS fiscal_year,
+            TO_CHAR(ACCOUNTING_PERIOD) AS period,
+            EMPL_RCD AS emp_rcd,
+            EFFSEQ AS eff_seq
+        FROM CAES_HCMODS.PS_UC_LL_FRNG_DTL_V
+        WHERE BUSINESS_UNIT IN ('DVCMP','UCANR')
+          AND OPERATING_UNIT IN ('3310','3110')
+          AND DML_IND <> 'D'
+          AND PAY_END_DT BETWEEN ? AND ?
+          AND NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL
+          AND (FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78'){Source204Arm(projects204)})
+        """;
+
+    private static string Source204Arm(IReadOnlyList<string> projects204) =>
+        projects204.Count > 0 ? $" OR PROJECT_ID IN ({ImportSql.QuoteList(projects204)})" : string.Empty;
+}

--- a/server.core/Import/UcPathTransactionsImportService.cs
+++ b/server.core/Import/UcPathTransactionsImportService.cs
@@ -9,7 +9,6 @@ namespace Server.Core.Import;
 
 public sealed class UcPathTransactionsImportService
 {
-    public const string ConnectionStringName = "Datamart";
     public const string HcmLinkedServer = "AIT_BISTG_PRD-CAES_HCMODS_APPUSER";
 
     private const int CommandTimeoutSeconds = DataDbConnection.ImportCommandTimeoutSeconds;
@@ -67,15 +66,7 @@ public sealed class UcPathTransactionsImportService
 
     public async Task<int> ImportAsync(DateOnly cycleStart, DateOnly cycleEnd, CancellationToken cancellationToken = default)
     {
-        var sourceConnectionString = _configuration["DATAMART_CONNECTION"]
-            ?? _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(sourceConnectionString))
-        {
-            throw new InvalidOperationException(
-                "No datamart connection string configured. Set the DATAMART_CONNECTION environment variable " +
-                $"or configure ConnectionStrings:{ConnectionStringName}.");
-        }
-
+        var sourceConnectionString = DatamartConnection.Resolve(_configuration);
         var destinationConnectionString = DataDbConnection.Resolve(
             _configuration,
             _dataDbContext.Database.GetConnectionString());
@@ -83,7 +74,7 @@ public sealed class UcPathTransactionsImportService
         await using var destination = new SqlConnection(destinationConnectionString);
         await destination.OpenAsync(cancellationToken);
 
-        var projects204 = await ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
+        var projects204 = await ImportSql.ReadListAsync(destination, ImportSql.Projects204Sql, cancellationToken);
         var (windowStart, windowEnd) = ImportSql.BufferedWindow(cycleStart, cycleEnd);
         var fteDenominatorHours = ImportSql.HoursInFederalFiscalYear(cycleEnd.Year);
 
@@ -270,19 +261,6 @@ public sealed class UcPathTransactionsImportService
           AND JOBCODE NOT LIKE ' %'
           AND EFFDT <= ?
         """;
-
-    private static async Task<List<string>> ReadListAsync(SqlConnection connection, string sql, CancellationToken ct)
-    {
-        var values = new List<string>();
-        await using var command = new SqlCommand(sql, connection) { CommandTimeout = CommandTimeoutSeconds };
-        await using var reader = await command.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            values.Add(reader.GetString(0));
-        }
-
-        return values;
-    }
 
     // Column names verified against the warehouse 2026-07-30 (ALL_TAB_COLUMNS for
     // both labor views). PAY_END_DT is the pay period end date used for the window

--- a/server.core/Migrations/20260729172616_AddImportRuns.Designer.cs
+++ b/server.core/Migrations/20260729172616_AddImportRuns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Server.Core.Data;
 
@@ -11,9 +12,11 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729172616_AddImportRuns")]
+    partial class AddImportRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -133,10 +136,6 @@ namespace server.core.Migrations
 
                     b.Property<DateTimeOffset?>("CompletedAt")
                         .HasColumnType("datetimeoffset");
-
-                    b.Property<string>("Detail")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("ErrorDetail")
                         .HasColumnType("nvarchar(max)");

--- a/server.core/Migrations/20260729172616_AddImportRuns.cs
+++ b/server.core/Migrations/20260729172616_AddImportRuns.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImportRun",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CycleStart = table.Column<DateOnly>(type: "date", nullable: false),
+                    CycleEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    TriggeredByEntraId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    TriggeredByName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    TriggeredByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true),
+                    StartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportRun", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImportRunStage",
+                schema: "app",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ImportRunId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Ordinal = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    RowCount = table.Column<int>(type: "int", nullable: true),
+                    StartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    ErrorDetail = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportRunStage", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ImportRunStage_ImportRun_ImportRunId",
+                        column: x => x.ImportRunId,
+                        principalSchema: "app",
+                        principalTable: "ImportRun",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportRun_Status",
+                schema: "app",
+                table: "ImportRun",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportRunStage_ImportRunId",
+                schema: "app",
+                table: "ImportRunStage",
+                column: "ImportRunId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImportRunStage",
+                schema: "app");
+
+            migrationBuilder.DropTable(
+                name: "ImportRun",
+                schema: "app");
+        }
+    }
+}

--- a/server.core/Migrations/20260730174853_AddImportRunStageDetail.Designer.cs
+++ b/server.core/Migrations/20260730174853_AddImportRunStageDetail.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Server.Core.Data;
 
@@ -11,9 +12,11 @@ using Server.Core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730174853_AddImportRunStageDetail")]
+    partial class AddImportRunStageDetail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server.core/Migrations/20260730174853_AddImportRunStageDetail.cs
+++ b/server.core/Migrations/20260730174853_AddImportRunStageDetail.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportRunStageDetail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Detail",
+                schema: "app",
+                table: "ImportRunStage",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Detail",
+                schema: "app",
+                table: "ImportRunStage");
+        }
+    }
+}

--- a/server/Controllers/ImportRunsController.cs
+++ b/server/Controllers/ImportRunsController.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Server.Authorization;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Models.ImportRuns;
+using System.Security.Claims;
+
+namespace Server.Controllers;
+
+public interface IImportRunStarter
+{
+    void Start(int runId);
+}
+
+public sealed class ImportRunStarter(IServiceScopeFactory scopeFactory, ILogger<ImportRunStarter> logger)
+    : IImportRunStarter
+{
+    public void Start(int runId)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var orchestrator = scope.ServiceProvider.GetRequiredService<ImportRunOrchestrator>();
+                await orchestrator.RunAsync(runId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Import run {RunId} crashed outside stage handling", runId);
+            }
+        });
+    }
+}
+
+public class ImportRunsController : ApiControllerBase
+{
+    private readonly AppDbContext _appDb;
+    private readonly IImportStageProvider _stageProvider;
+    private readonly IImportRunStarter _runStarter;
+    private readonly IImportReadinessCheck _readinessCheck;
+
+    public ImportRunsController(
+        AppDbContext appDb,
+        IImportStageProvider stageProvider,
+        IImportRunStarter runStarter,
+        IImportReadinessCheck readinessCheck)
+    {
+        _appDb = appDb;
+        _stageProvider = stageProvider;
+        _runStarter = runStarter;
+        _readinessCheck = readinessCheck;
+    }
+
+    // POST api/importruns
+    // Cycle dates come from the confirmed fiscal period, never from the client:
+    // a stale browser tab must not be able to import the wrong year.
+    [HttpPost]
+    public async Task<ActionResult<ImportRunDto>> Start(CancellationToken cancellationToken)
+    {
+        var workflowRun = await _appDb.WorkflowRuns
+            .SingleOrDefaultAsync(r => r.IsCurrent, cancellationToken);
+        if (workflowRun is null)
+        {
+            return Conflict("No fiscal period has been confirmed in Project Identification.");
+        }
+
+        if (await _appDb.ImportRuns.AnyAsync(r => r.Status == ImportRunStatus.Running, cancellationToken))
+        {
+            return Conflict("An import run is already in progress.");
+        }
+
+        if (await _readinessCheck.GetBlockingIssueAsync(
+                workflowRun.CycleStart, workflowRun.CycleEnd, cancellationToken) is { } blockingIssue)
+        {
+            return Conflict(blockingIssue);
+        }
+
+        var run = new ImportRun
+        {
+            CycleStart = workflowRun.CycleStart,
+            CycleEnd = workflowRun.CycleEnd,
+            Status = ImportRunStatus.Running,
+            TriggeredByEntraId = User.GetEntraId(),
+            TriggeredByName = User.FindFirst("name")?.Value ?? User.Identity?.Name,
+            TriggeredByEmail = User.FindFirst("preferred_username")?.Value ?? User.FindFirst(ClaimTypes.Email)?.Value,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages = _stageProvider.StageNames
+                .Select((name, i) => new ImportRunStage { Name = name, Ordinal = i, Status = ImportStageStatus.Pending })
+                .ToList(),
+        };
+
+        _appDb.ImportRuns.Add(run);
+        await _appDb.SaveChangesAsync(cancellationToken);
+
+        _runStarter.Start(run.Id);
+
+        return ImportRunDto.From(run);
+    }
+
+    // GET api/importruns/current
+    [HttpGet("current")]
+    public async Task<ActionResult<ImportRunDto>> Current(CancellationToken cancellationToken)
+    {
+        var run = await _appDb.ImportRuns
+            .Include(r => r.Stages)
+            .OrderByDescending(r => r.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return run is null ? NoContent() : ImportRunDto.From(run);
+    }
+}

--- a/server/Models/ImportRuns/ImportRunDtos.cs
+++ b/server/Models/ImportRuns/ImportRunDtos.cs
@@ -1,0 +1,45 @@
+using Server.Core.Domain;
+
+namespace Server.Models.ImportRuns;
+
+public sealed record ImportRunStageDto(
+    string Name,
+    int Ordinal,
+    string Status,
+    int? RowCount,
+    string? Detail,
+    DateTimeOffset? StartedAt,
+    DateTimeOffset? CompletedAt,
+    string? ErrorDetail);
+
+public sealed record ImportRunDto(
+    int Id,
+    DateOnly CycleStart,
+    DateOnly CycleEnd,
+    string Status,
+    string? TriggeredByName,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? CompletedAt,
+    IReadOnlyList<ImportRunStageDto> Stages)
+{
+    public static ImportRunDto From(ImportRun run) => new(
+        run.Id,
+        run.CycleStart,
+        run.CycleEnd,
+        run.Status,
+        run.TriggeredByName,
+        run.StartedAt,
+        run.CompletedAt,
+        run.Stages
+            .OrderBy(stage => stage.Ordinal)
+            .Select(stage => new ImportRunStageDto(
+                stage.Name,
+                stage.Ordinal,
+                stage.Status,
+                stage.RowCount,
+                stage.Detail,
+                stage.StartedAt,
+                stage.CompletedAt,
+                stage.ErrorDetail))
+            .ToList());
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Server.Authorization;
+using Server.Controllers;
 using Server.Core.Data;
 using Server.Import;
 using Server.Core.Import;
@@ -59,6 +60,14 @@ builder.Services.AddSingleton<IFlatFileImportRegistry, FlatFileImportRegistry>()
 builder.Services.AddScoped<IFlatFileImportService, FlatFileImportService>();
 builder.Services.AddScoped<IProjectIdentificationService, ProjectIdentificationService>();
 builder.Services.AddScoped<IProjectListService, ProjectListService>();
+builder.Services.AddScoped<ImportRunOrchestrator>();
+builder.Services.AddSingleton<IImportRunStarter, ImportRunStarter>();
+builder.Services.AddScoped<ChartSegmentsImportService>();
+builder.Services.AddScoped<AeTransactionsImportService>();
+builder.Services.AddScoped<UcPathTransactionsImportService>();
+builder.Services.AddScoped<SprocStageService>();
+builder.Services.AddScoped<IImportReadinessCheck, ImportReadinessCheck>();
+builder.Services.AddScoped<IImportStageProvider, ImportStageProvider>();
 // add auth policies here
 
 // add db context (check secrets first, then config, then default)

--- a/tests/server.tests/Data/DatamartConnectionTests.cs
+++ b/tests/server.tests/Data/DatamartConnectionTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Server.Core.Data;
+
+namespace Server.Tests.Data;
+
+public class DatamartConnectionTests
+{
+    [Fact]
+    public void Resolve_prefers_environment_variable_over_named_connection()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [DatamartConnection.EnvironmentVariableName] = "env-connection",
+            [$"ConnectionStrings:{DatamartConnection.ConnectionStringName}"] = "named-connection",
+        });
+
+        var connectionString = DatamartConnection.Resolve(configuration);
+
+        connectionString.Should().Be("env-connection");
+    }
+
+    [Fact]
+    public void Resolve_skips_blank_environment_variable_and_uses_named_connection()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [DatamartConnection.EnvironmentVariableName] = "   ",
+            [$"ConnectionStrings:{DatamartConnection.ConnectionStringName}"] = "named-connection",
+        });
+
+        var connectionString = DatamartConnection.Resolve(configuration);
+
+        connectionString.Should().Be("named-connection");
+    }
+
+    [Fact]
+    public void Resolve_throws_when_nothing_is_configured()
+    {
+        var configuration = BuildConfiguration([]);
+
+        var resolve = () => DatamartConnection.Resolve(configuration);
+
+        resolve.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{DatamartConnection.EnvironmentVariableName}*");
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/tests/server.tests/Import/AeTransactionsImportServiceTests.cs
+++ b/tests/server.tests/Import/AeTransactionsImportServiceTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class AeTransactionsImportServiceTests
+{
+    private static readonly string[] Periods = ["Jul-24", "Aug-24"];
+    private static readonly string[] Depts = ["APLS001", "AANS001"];
+    private static readonly string[] Bcbs = ["BCBS001"];
+    private static readonly string[] Projects = ["K30V4ALIUR"];
+
+    [Fact]
+    public void BuildRemoteQuery_filters_to_actuals_and_periods()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, Bcbs, Projects);
+
+        query.Should().Contain("FROM ae_dwh.transactional_listing_report");
+        query.Should().Contain("actual_flag = 'A'");
+        query.Should().Contain("period_name IN ('Jul-24','Aug-24')");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_casts_the_wide_net_with_dept_204_and_bcbs_arms()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, Bcbs, Projects);
+
+        query.Should().Contain("financial_department IN ('APLS001','AANS001')");
+        query.Should().Contain("project IN ('K30V4ALIUR')");
+        query.Should().Contain("financial_department IN ('BCBS001') AND fund = '13U02'");
+        // the wide net has no purpose, account, or activity filters (the segment
+        // columns themselves appear in the select list, so assert on filter shapes)
+        query.Should().NotContain("purpose NOT IN");
+        query.Should().NotContain("account NOT LIKE");
+        query.Should().NotContain("activity NOT IN");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_omits_empty_optional_arms()
+    {
+        var query = AeTransactionsImportService.BuildRemoteQuery(Periods, Depts, [], []);
+
+        query.Should().NotContain("13U02");
+        query.Should().NotContain("project IN");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_requires_departments()
+    {
+        var act = () => AeTransactionsImportService.BuildRemoteQuery(Periods, [], Bcbs, Projects);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*CAES/ANR department list is empty*");
+    }
+}

--- a/tests/server.tests/Import/ChartSegmentsImportServiceTests.cs
+++ b/tests/server.tests/Import/ChartSegmentsImportServiceTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ChartSegmentsImportServiceTests
+{
+    [Fact]
+    public void Segments_cover_all_eight_erp_tables_in_stage_order()
+    {
+        ChartSegmentsImportService.Segments.Select(s => s.SourceTable).Should().Equal(
+            "ae_dwh.erp_entity", "ae_dwh.erp_fund", "ae_dwh.erp_fin_dept", "ae_dwh.erp_account",
+            "ae_dwh.erp_purpose", "ae_dwh.erp_program", "ae_dwh.erp_project", "ae_dwh.erp_activity");
+        ChartSegmentsImportService.Segments.Select(s => s.SegmentName).Should().Equal(
+            "Entity", "Fund", "FinancialDepartment", "Account",
+            "Purpose", "Program", "Project", "Activity");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_selects_a_segment_name_literal_from_the_source_table()
+    {
+        var query = ChartSegmentsImportService.BuildRemoteQuery("Fund", "ae_dwh.erp_fund");
+
+        query.Should().Contain("CAST('Fund' AS VARCHAR(30)) AS segment_name");
+        query.Should().Contain("FROM ae_dwh.erp_fund");
+        query.Should().Contain("parent_level_0_code");
+        query.Should().Contain("parent_level_5_code");
+        query.Should().NotMatchRegex(@"parent_level_\d[,\s]");
+    }
+
+    [Fact]
+    public void BuildRemoteQuery_rejects_unknown_segment_names()
+    {
+        var act = () => ChartSegmentsImportService.BuildRemoteQuery("Robert'); DROP TABLE", "ae_dwh.erp_fund");
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/server.tests/Import/ImportRunEntityTests.cs
+++ b/tests/server.tests/Import/ImportRunEntityTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Server.Core.Domain;
+
+namespace Server.Tests.Import;
+
+public class ImportRunEntityTests
+{
+    [Fact]
+    public async Task ImportRun_round_trips_with_stages()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+
+        var run = new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages =
+            {
+                new ImportRunStage { Name = "ChartSegments: Fund", Ordinal = 2, Status = ImportStageStatus.Pending },
+            },
+        };
+
+        db.ImportRuns.Add(run);
+        await db.SaveChangesAsync();
+
+        var loaded = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        loaded.Stages.Should().ContainSingle(s => s.Name == "ChartSegments: Fund" && s.Status == "Pending");
+        loaded.Status.Should().Be("Running");
+    }
+}

--- a/tests/server.tests/Import/ImportRunOrchestratorTests.cs
+++ b/tests/server.tests/Import/ImportRunOrchestratorTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportRunOrchestratorTests
+{
+    private sealed class FakeStageProvider(params ImportStage[] stages) : IImportStageProvider
+    {
+        public IReadOnlyList<string> StageNames { get; } = stages.Select(s => s.Name).ToList();
+        public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context) => stages;
+    }
+
+    private static async Task<int> SeedRunAsync(AppDbContext db, IImportStageProvider provider)
+    {
+        var run = new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages = provider.StageNames
+                .Select((name, i) => new ImportRunStage { Name = name, Ordinal = i, Status = ImportStageStatus.Pending })
+                .ToList(),
+        };
+        db.ImportRuns.Add(run);
+        await db.SaveChangesAsync();
+        return run.Id;
+    }
+
+    [Fact]
+    public async Task Runs_stages_in_order_and_records_row_counts()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var order = new List<string>();
+        var provider = new FakeStageProvider(
+            ImportStage.FromRowCount("one", _ => { order.Add("one"); return Task.FromResult(5); }),
+            new ImportStage("two", _ =>
+            {
+                order.Add("two");
+                return Task.FromResult(new ImportStageResult(7, "7 AE projects, 3 NIFA projects"));
+            }));
+        var runId = await SeedRunAsync(db, provider);
+
+        await new ImportRunOrchestrator(db, provider, NullLogger<ImportRunOrchestrator>.Instance).RunAsync(runId);
+
+        order.Should().Equal("one", "two");
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Succeeded);
+        run.CompletedAt.Should().NotBeNull();
+        run.Stages.Should().OnlyContain(s => s.Status == ImportStageStatus.Succeeded);
+        run.Stages.Single(s => s.Name == "one").RowCount.Should().Be(5);
+        run.Stages.Single(s => s.Name == "one").Detail.Should().BeNull();
+        run.Stages.Single(s => s.Name == "two").RowCount.Should().Be(7);
+        run.Stages.Single(s => s.Name == "two").Detail.Should().Be("7 AE projects, 3 NIFA projects");
+    }
+
+    [Fact]
+    public async Task Failing_stage_stops_the_run_and_leaves_later_stages_pending()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var provider = new FakeStageProvider(
+            ImportStage.FromRowCount("one", _ => Task.FromResult(1)),
+            ImportStage.FromRowCount("boom", _ => throw new InvalidOperationException("warehouse offline")),
+            ImportStage.FromRowCount("three", _ => Task.FromResult(3)));
+        var runId = await SeedRunAsync(db, provider);
+
+        await new ImportRunOrchestrator(db, provider, NullLogger<ImportRunOrchestrator>.Instance).RunAsync(runId);
+
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Failed);
+        run.Stages.Single(s => s.Name == "one").Status.Should().Be(ImportStageStatus.Succeeded);
+        var failed = run.Stages.Single(s => s.Name == "boom");
+        failed.Status.Should().Be(ImportStageStatus.Failed);
+        failed.ErrorDetail.Should().Contain("warehouse offline");
+        run.Stages.Single(s => s.Name == "three").Status.Should().Be(ImportStageStatus.Pending);
+    }
+
+    [Fact]
+    public async Task Startup_sweep_marks_running_runs_failed()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        db.ImportRuns.Add(new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            Stages =
+            {
+                new ImportRunStage { Name = "one", Ordinal = 0, Status = ImportStageStatus.Succeeded },
+                new ImportRunStage { Name = "two", Ordinal = 1, Status = ImportStageStatus.Running },
+                new ImportRunStage { Name = "three", Ordinal = 2, Status = ImportStageStatus.Pending },
+            },
+        });
+        await db.SaveChangesAsync();
+
+        await ImportRunOrchestrator.FailInterruptedRunsAsync(db);
+
+        var run = await db.ImportRuns.Include(r => r.Stages).SingleAsync();
+        run.Status.Should().Be(ImportRunStatus.Failed);
+        run.Stages.Single(s => s.Name == "two").Status.Should().Be(ImportStageStatus.Failed);
+        run.Stages.Single(s => s.Name == "two").ErrorDetail.Should().Be("Interrupted by application restart.");
+        run.Stages.Single(s => s.Name == "one").Status.Should().Be(ImportStageStatus.Succeeded);
+        run.Stages.Single(s => s.Name == "three").Status.Should().Be(ImportStageStatus.Pending);
+    }
+}

--- a/tests/server.tests/Import/ImportRunsControllerTests.cs
+++ b/tests/server.tests/Import/ImportRunsControllerTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Server.Controllers;
+using Server.Core.Data;
+using Server.Core.Domain;
+using Server.Core.Import;
+using Server.Models.ImportRuns;
+using System.Security.Claims;
+
+namespace Server.Tests.Import;
+
+public class ImportRunsControllerTests
+{
+    private sealed class FakeStageProvider : IImportStageProvider
+    {
+        public IReadOnlyList<string> StageNames => ImportStageNames.All;
+        public IReadOnlyList<ImportStage> BuildStages(ImportRunContext context) =>
+            StageNames.Select(name => ImportStage.FromRowCount(name, _ => Task.FromResult(0))).ToList();
+    }
+
+    private sealed class RecordingRunStarter : IImportRunStarter
+    {
+        public List<int> StartedRunIds { get; } = [];
+        public void Start(int runId) => StartedRunIds.Add(runId);
+    }
+
+    private sealed class FakeReadinessCheck(string? blockingIssue) : IImportReadinessCheck
+    {
+        public Task<string?> GetBlockingIssueAsync(
+            DateOnly cycleStart,
+            DateOnly cycleEnd,
+            CancellationToken cancellationToken) => Task.FromResult(blockingIssue);
+    }
+
+    private static async Task<WorkflowRun> SeedWorkflowRunAsync(AppDbContext db)
+    {
+        var run = new WorkflowRun
+        {
+            FiscalYear = "FY25",
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            IsCurrent = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.WorkflowRuns.Add(run);
+        await db.SaveChangesAsync();
+        return run;
+    }
+
+    private static ImportRunsController CreateController(
+        AppDbContext db, RecordingRunStarter starter, string? blockingIssue = null)
+    {
+        var controller = new ImportRunsController(
+            db, new FakeStageProvider(), starter, new FakeReadinessCheck(blockingIssue));
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("name", "Rob Martinsen"), new Claim("preferred_username", "rob@ucdavis.edu")],
+                    "test")),
+            },
+        };
+        return controller;
+    }
+
+    [Fact]
+    public async Task Start_creates_run_with_all_pending_stages_and_starts_it()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        await SeedWorkflowRunAsync(db);
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        var dto = result.Value!;
+        dto.Status.Should().Be(ImportRunStatus.Running);
+        dto.CycleStart.Should().Be(new DateOnly(2024, 10, 1));
+        dto.CycleEnd.Should().Be(new DateOnly(2025, 9, 30));
+        dto.Stages.Should().HaveCount(13);
+        dto.Stages.Should().OnlyContain(s => s.Status == ImportStageStatus.Pending);
+        dto.Stages.Select(s => s.Name).Should().ContainInOrder(ImportStageNames.All);
+        starter.StartedRunIds.Should().Equal(dto.Id);
+        (await db.ImportRuns.Include(r => r.Stages).SingleAsync()).Stages.Should().HaveCount(13);
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_a_run_is_already_running()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        db.ImportRuns.Add(new ImportRun
+        {
+            CycleStart = new DateOnly(2024, 10, 1),
+            CycleEnd = new DateOnly(2025, 9, 30),
+            Status = ImportRunStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+        await SeedWorkflowRunAsync(db);
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+        starter.StartedRunIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_project_identification_is_not_ready()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var starter = new RecordingRunStarter();
+        await SeedWorkflowRunAsync(db);
+        var controller = CreateController(
+            db, starter, "Unresolved project issues exist; resolve them in Project Identification first.");
+
+        var result = await controller.Start(CancellationToken.None);
+
+        var conflict = result.Result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().Be("Unresolved project issues exist; resolve them in Project Identification first.");
+        starter.StartedRunIds.Should().BeEmpty();
+        (await db.ImportRuns.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Start_returns_409_when_no_fiscal_period_is_confirmed()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var starter = new RecordingRunStarter();
+        var controller = CreateController(db, starter);
+
+        var result = await controller.Start(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ConflictObjectResult>();
+        starter.StartedRunIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Current_returns_latest_run_or_204()
+    {
+        await using var db = TestDbContextFactory.CreateInMemory();
+        var controller = CreateController(db, new RecordingRunStarter());
+
+        (await controller.Current(CancellationToken.None)).Result.Should().BeOfType<NoContentResult>();
+
+        db.ImportRuns.AddRange(
+            new ImportRun { CycleStart = new(2023, 10, 1), CycleEnd = new(2024, 9, 30), Status = ImportRunStatus.Succeeded, StartedAt = DateTimeOffset.UtcNow.AddDays(-2) },
+            new ImportRun { CycleStart = new(2024, 10, 1), CycleEnd = new(2025, 9, 30), Status = ImportRunStatus.Failed, StartedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var dto = (await controller.Current(CancellationToken.None)).Value!;
+        dto.Status.Should().Be(ImportRunStatus.Failed);
+        dto.CycleStart.Should().Be(new DateOnly(2024, 10, 1));
+    }
+}

--- a/tests/server.tests/Import/ImportSqlTests.cs
+++ b/tests/server.tests/Import/ImportSqlTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportSqlTests
+{
+    [Fact]
+    public void PeriodNames_spans_year_boundaries_in_en_us()
+    {
+        ImportSql.PeriodNames(new DateOnly(2024, 11, 15), new DateOnly(2025, 2, 1))
+            .Should().Equal("Nov-24", "Dec-24", "Jan-25", "Feb-25");
+    }
+
+    [Fact]
+    public void QuoteList_doubles_embedded_quotes()
+    {
+        ImportSql.QuoteList(["ABC", "O'Neil"]).Should().Be("'ABC','O''Neil'");
+    }
+
+    [Fact]
+    public void HoursInFederalFiscalYear_handles_leap_cycle()
+    {
+        ImportSql.HoursInFederalFiscalYear(2024).Should().Be(2096);
+        ImportSql.HoursInFederalFiscalYear(2025).Should().Be(2088);
+    }
+
+    [Fact]
+    public void BufferedWindow_extends_three_months_each_side()
+    {
+        ImportSql.BufferedWindow(new DateOnly(2024, 10, 1), new DateOnly(2025, 9, 30))
+            .Should().Be((new DateOnly(2024, 7, 1), new DateOnly(2025, 12, 30)));
+    }
+}

--- a/tests/server.tests/Import/ImportStageProviderTests.cs
+++ b/tests/server.tests/Import/ImportStageProviderTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class ImportStageProviderTests
+{
+    private static ImportStageProvider CreateProvider()
+    {
+        var db = TestDbContextFactory.CreateDataInMemory();
+        var config = new ConfigurationBuilder().Build();
+        return new ImportStageProvider(
+            new ChartSegmentsImportService(db, config, NullLogger<ChartSegmentsImportService>.Instance),
+            new AeTransactionsImportService(db, config, NullLogger<AeTransactionsImportService>.Instance),
+            new UcPathTransactionsImportService(db, config, NullLogger<UcPathTransactionsImportService>.Instance),
+            new SprocStageService(db, config));
+    }
+
+    [Fact]
+    public void Stage_names_match_the_canonical_order()
+    {
+        CreateProvider().StageNames.Should().Equal(ImportStageNames.All);
+    }
+
+    [Fact]
+    public void BuildStages_produces_one_stage_per_name_in_order()
+    {
+        var context = new ImportRunContext(1, new DateOnly(2024, 10, 1), new DateOnly(2025, 9, 30));
+        var stages = CreateProvider().BuildStages(context);
+
+        stages.Select(s => s.Name).Should().Equal(ImportStageNames.All);
+    }
+}

--- a/tests/server.tests/Import/UcPathTransactionsImportServiceTests.cs
+++ b/tests/server.tests/Import/UcPathTransactionsImportServiceTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Server.Core.Import;
+
+namespace Server.Tests.Import;
+
+public class UcPathTransactionsImportServiceTests
+{
+    private static readonly string[] Projects = ["K30V4ALIUR", "SP1A242572"];
+
+    [Fact]
+    public void BuildSalaryQuery_applies_the_2025_source_filter_with_204_arm()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2088);
+
+        query.Should().Contain("FROM CAES_HCMODS.PS_UC_LL_SAL_DTL_V");
+        query.Should().Contain("BUSINESS_UNIT IN ('DVCMP','UCANR')");
+        query.Should().Contain("OPERATING_UNIT IN ('3310','3110')");
+        query.Should().Contain("DML_IND <> 'D'");
+        query.Should().Contain("FUND_CODE = '13U02' OR CLASS_FLD IN ('44','45','78')");
+        query.Should().Contain("PROJECT_ID IN ('K30V4ALIUR','SP1A242572')");
+        // pay period end date is the window filter, bound as placeholders
+        query.Should().Contain("PAY_END_DT BETWEEN ? AND ?");
+    }
+
+    [Fact]
+    public void BuildSalaryQuery_computes_fte_payrate_and_salary_marker_in_source_sql()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2096);
+
+        query.Should().Contain("HOURS1 / 2096");    // CalculatedFte denominator
+        query.Should().Contain("'S' AS fringe_benefit_salary_cd");
+        query.Should().Contain("NULLIF(TRIM(POSITION_NBR), '') IS NOT NULL");
+    }
+
+    [Fact]
+    public void BuildSalaryQuery_uses_the_verified_view_column_names()
+    {
+        var query = UcPathTransactionsImportService.BuildSalaryQuery(Projects, 2088);
+
+        query.Should().Contain("JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ");
+        query.Should().Contain("HOURS1 AS hours");
+        query.Should().Contain("MONETARY_AMOUNT AS amount");
+        // JOBCODE holds 6-char values like '003252'; the title code is the last 4
+        query.Should().Contain("SUBSTR(JOBCODE, -4)");
+        query.Should().Contain("UC_EARNCD_DESCR), '') AS ern_description");
+        query.Should().Contain("UC_PCT_TOT_PAY AS paid_percent");
+        query.Should().Contain("UC_DRV_EFT_PCT AS ern_derived_percent");
+        query.Should().Contain("TO_CHAR(ACCOUNTING_PERIOD) AS period");
+        // absent from both labor views
+        query.Should().NotContain("FINANCE_DOC_TYPE_CD");
+        query.Should().NotContain("RATE_TYPE_CD");
+    }
+
+    [Fact]
+    public void BuildFringeQuery_marks_fringe_rows_with_placeholder_ern()
+    {
+        var query = UcPathTransactionsImportService.BuildFringeQuery(Projects);
+
+        query.Should().Contain("FROM CAES_HCMODS.PS_UC_LL_FRNG_DTL_V");
+        query.Should().Contain("'XXX' AS erncd");
+        query.Should().Contain("'F' AS fringe_benefit_salary_cd");
+        query.Should().Contain("0 AS calculated_fte");
+    }
+
+    [Fact]
+    public void BuildFringeQuery_uses_the_verified_view_column_names()
+    {
+        var query = UcPathTransactionsImportService.BuildFringeQuery(Projects);
+
+        query.Should().Contain("JOURNAL_ID || '_' || JOURNAL_LINE || '_' || UC_ADDL_SEQ");
+        query.Should().Contain("MONETARY_AMOUNT AS amount");
+        // the fringe view has no JOBCODE; enrichment backfills it
+        query.Should().Contain("CAST(NULL AS VARCHAR2(24)) AS job_code");
+        query.Should().Contain("CAST(NULL AS VARCHAR2(120)) AS ern_description");
+        query.Should().NotContain("FINANCE_DOC_TYPE_CD");
+        query.Should().NotContain("RATE_TYPE_CD");
+    }
+
+    [Fact]
+    public void Queries_omit_the_204_arm_when_no_projects_exist()
+    {
+        UcPathTransactionsImportService.BuildSalaryQuery([], 2088).Should().NotContain("PROJECT_ID IN");
+        UcPathTransactionsImportService.BuildFringeQuery([]).Should().NotContain("PROJECT_ID IN");
+    }
+
+    [Fact]
+    public void BuildNamesQuery_prefers_the_names_view()
+    {
+        var query = UcPathTransactionsImportService.BuildNamesQuery();
+
+        query.Should().Contain("CAES_HCMODS.UCD_PS_NAMES_V");
+    }
+
+    [Fact]
+    public void BuildJobCodeQuery_filters_conversion_rows_and_bounds_effdt()
+    {
+        var query = UcPathTransactionsImportService.BuildJobCodeQuery();
+
+        query.Should().Contain("CAES_HCMODS.PS_JOB_V");
+        query.Should().Contain("JOBCODE <> 'CONV'");
+        query.Should().Contain("EFFDT <= ?");
+    }
+}

--- a/tests/server.tests/ProjectList/ProjectListSqlTests.cs
+++ b/tests/server.tests/ProjectList/ProjectListSqlTests.cs
@@ -79,7 +79,8 @@ public class ProjectListSqlTests
 
         sql.Should().Contain("@CycleStart DATE");
         sql.Should().Contain("@CycleEnd DATE");
-        sql.Should().Contain("FROM [data].[ProjectListForCycle](@CycleStart, @CycleEnd)");
+        // the non-Clean check lives in the shared readiness function
+        sql.Should().Contain("[data].[ImportBlockingIssueForCycle](@CycleStart, @CycleEnd)");
         sql.Should().Contain("FROM [data].[NifaProjectsForCycle](@CycleStart, @CycleEnd) nv");
         sql.Should().NotContain("[data].[v_ProjectList]");
         sql.Should().NotContain("[data].[v_NifaProjects]");


### PR DESCRIPTION
Brings the full expense import stack to main. This branch accumulated the stacked PRs that were merged into each other rather than reaching main: #49 (database objects), #52 (run/stage infrastructure), #50 (pipeline services and endpoints), and #51 (Data Import workflow stage UI), plus the review follow-ups on #50 and #51 and a merge of current main.

Note: #49's merge into swe/IssueResolution predated the #50/#51 merges, so this PR is what actually lands the pipeline and UI.

- AE, ChartSegments, and UCPath import services with shared datamart connection resolution
- Import run orchestration, readiness checks, and per-stage progress endpoints
- Data Import workflow stage between Project Identification and Data Classification, with query error states and server error detail surfaced
- 195 server and 52 client tests passing on the merged tree

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Data Import workflow stage with fiscal-period details, buffered import windows, run status, stage progress, errors, retry handling, and import initiation.
  - Added end-to-end import processing for financial, project, transaction, and classification data.
  - Added readiness checks to prevent imports when required project information is incomplete.
  - Added progress tracking and recovery for interrupted imports.

- **Bug Fixes**
  - Improved transaction account matching and earning-code description handling.
  - Added department views and refined project readiness reporting.

- **Tests**
  - Added comprehensive coverage for import workflows, validation, processing stages, error handling, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->